### PR TITLE
Fix bug with mouse hover triggerring on tooltip children

### DIFF
--- a/src/js/index.jsx
+++ b/src/js/index.jsx
@@ -87,7 +87,7 @@ const ReactTooltip = React.createClass({
   componentDidMount() {
     var targetArray = document.querySelectorAll("[data-tip]");
     for(var i = 0; i < targetArray.length; i++) {
-      targetArray[i].addEventListener("mouseover", this.showTooltip, false);
+      targetArray[i].addEventListener("mouseenter", this.showTooltip, false);
       targetArray[i].addEventListener("mousemove", this.updateTooltip, false);
       targetArray[i].addEventListener("mouseleave", this.hideTooltip, false);
     }
@@ -96,7 +96,7 @@ const ReactTooltip = React.createClass({
   componentWillUnmount() {
     var targetArray = document.querySelectorAll("[data-tip]");
     for(var i = 0; i < targetArray.length; i++) {
-      targetArray[i].removeEventListener("mouseover", this.showTooltip);
+      targetArray[i].removeEventListener("mouseenter", this.showTooltip);
       targetArray[i].removeEventListener("mousemove", this.updateTooltip);
       targetArray[i].removeEventListener("mouseleave", this.hideTooltip);
     }


### PR DESCRIPTION
When tooltip contains child elements, the mousenter event get triggered on the children and causes the tooltip to reappear with no content. The issue can be solved simply replacing mouseover with mouseenter.