### PR TITLE
Change module definition to UMD

### DIFF
--- a/dist/react-tooltip.js
+++ b/dist/react-tooltip.js
@@ -1,147 +1,152 @@
-'use strict';
+(function (global, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define(['exports', 'module', 'react', 'classnames'], factory);
+  } else if (typeof exports !== 'undefined' && typeof module !== 'undefined') {
+    factory(exports, module, require('react'), require('classnames'));
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory(mod.exports, mod, global.React, global.classname);
+    global.index = mod.exports;
+  }
+})(this, function (exports, module, _react, _classnames) {
+  'use strict';
 
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
+  function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+  var _React = _interopRequireDefault(_react);
 
-var _react = require('react');
+  var _classname = _interopRequireDefault(_classnames);
 
-var _react2 = _interopRequireDefault(_react);
+  var ReactTooltip = _React['default'].createClass({
 
-var _classnames = require('classnames');
+    displayName: 'ReactTooltip',
 
-var _classnames2 = _interopRequireDefault(_classnames);
+    propTypes: {
+      place: _React['default'].PropTypes.string,
+      type: _React['default'].PropTypes.string,
+      effect: _React['default'].PropTypes.string },
 
-var ReactTooltip = _react2['default'].createClass({
+    getInitialState: function getInitialState() {
+      return {
+        show: false,
+        placeholder: '',
+        x: 'NONE',
+        y: 'NONE',
+        place: '',
+        type: '',
+        effect: '' };
+    },
 
-  displayName: 'ReactTooltip',
-
-  propTypes: {
-    place: _react2['default'].PropTypes.string,
-    type: _react2['default'].PropTypes.string,
-    effect: _react2['default'].PropTypes.string },
-
-  getInitialState: function getInitialState() {
-    return {
-      show: false,
-      placeholder: '',
-      x: 'NONE',
-      y: 'NONE',
-      place: '',
-      type: '',
-      effect: '' };
-  },
-
-  showTooltip: function showTooltip(e) {
-    this.setState({
-      placeholder: e.target.getAttribute('data-tip'),
-      place: e.target.getAttribute('data-place') ? e.target.getAttribute('data-place') : this.props.place ? this.props.place : 'top',
-      type: e.target.getAttribute('data-type') ? e.target.getAttribute('data-type') : this.props.type ? this.props.type : 'dark',
-      effect: e.target.getAttribute('data-effect') ? e.target.getAttribute('data-effect') : this.props.effect ? this.props.effect : 'float' });
-    this.updateTooltip(e);
-  },
-
-  updateTooltip: function updateTooltip(e) {
-    if (this.state.effect === 'float') {
+    showTooltip: function showTooltip(e) {
       this.setState({
-        show: true,
-        x: e.clientX,
-        y: e.clientY
-      });
-    } else if (this.state.effect === 'solid') {
-      var targetTop = e.target.getBoundingClientRect().top;
-      var targetLeft = e.target.getBoundingClientRect().left;
+        placeholder: e.target.getAttribute('data-tip'),
+        place: e.target.getAttribute('data-place') ? e.target.getAttribute('data-place') : this.props.place ? this.props.place : 'top',
+        type: e.target.getAttribute('data-type') ? e.target.getAttribute('data-type') : this.props.type ? this.props.type : 'dark',
+        effect: e.target.getAttribute('data-effect') ? e.target.getAttribute('data-effect') : this.props.effect ? this.props.effect : 'float' });
+      this.updateTooltip(e);
+    },
+
+    updateTooltip: function updateTooltip(e) {
+      if (this.state.effect === 'float') {
+        this.setState({
+          show: true,
+          x: e.clientX,
+          y: e.clientY
+        });
+      } else if (this.state.effect === 'solid') {
+        var targetTop = e.target.getBoundingClientRect().top;
+        var targetLeft = e.target.getBoundingClientRect().left;
+        var tipWidth = document.querySelector('[data-id=\'tooltip\']') ? document.querySelector('[data-id=\'tooltip\']').clientWidth : 0;
+        var tipHeight = document.querySelector('[data-id=\'tooltip\']') ? document.querySelector('[data-id=\'tooltip\']').clientHeight : 0;
+        var targetWidth = e.target.clientWidth;
+        var targetHeight = e.target.clientHeight;
+        var place = this.state.place;
+
+        var x = undefined,
+            y = undefined;
+        if (place === 'top') {
+          x = targetLeft - tipWidth / 2 + targetWidth / 2;
+          y = targetTop - tipHeight - 8;
+        } else if (place === 'bottom') {
+          x = targetLeft - tipWidth / 2 + targetWidth / 2;
+          y = targetTop + targetHeight + 8;
+        } else if (place === 'left') {
+          x = targetLeft - tipWidth - 6;
+          y = targetTop + targetHeight / 2 - tipHeight / 2;
+        } else if (place === 'right') {
+          x = targetLeft + targetWidth + 6;
+          y = targetTop + targetHeight / 2 - tipHeight / 2;
+        }
+        this.setState({
+          show: true,
+          x: this.state.x === 'NONE' ? x : this.state.x,
+          y: this.state.y === 'NONE' ? y : this.state.y
+        });
+      }
+    },
+
+    hideTooltip: function hideTooltip(e) {
+      this.setState({
+        show: false,
+        x: 'NONE',
+        y: 'NONE' });
+    },
+
+    componentDidMount: function componentDidMount() {
+      var targetArray = document.querySelectorAll('[data-tip]');
+      for (var i = 0; i < targetArray.length; i++) {
+        targetArray[i].addEventListener('mouseenter', this.showTooltip, false);
+        targetArray[i].addEventListener('mousemove', this.updateTooltip, false);
+        targetArray[i].addEventListener('mouseleave', this.hideTooltip, false);
+      }
+    },
+
+    componentWillUnmount: function componentWillUnmount() {
+      var targetArray = document.querySelectorAll('[data-tip]');
+      for (var i = 0; i < targetArray.length; i++) {
+        targetArray[i].removeEventListener('mouseenter', this.showTooltip);
+        targetArray[i].removeEventListener('mousemove', this.updateTooltip);
+        targetArray[i].removeEventListener('mouseleave', this.hideTooltip);
+      }
+    },
+
+    render: function render() {
       var tipWidth = document.querySelector('[data-id=\'tooltip\']') ? document.querySelector('[data-id=\'tooltip\']').clientWidth : 0;
       var tipHeight = document.querySelector('[data-id=\'tooltip\']') ? document.querySelector('[data-id=\'tooltip\']').clientHeight : 0;
-      var targetWidth = e.target.clientWidth;
-      var targetHeight = e.target.clientHeight;
-      var place = this.state.place;
+      var offset = { x: 0, y: 0 };
+      var effect = this.state.effect;
 
-      var x = undefined,
-          y = undefined;
-      if (place === 'top') {
-        x = targetLeft - tipWidth / 2 + targetWidth / 2;
-        y = targetTop - tipHeight - 8;
-      } else if (place === 'bottom') {
-        x = targetLeft - tipWidth / 2 + targetWidth / 2;
-        y = targetTop + targetHeight + 8;
-      } else if (place === 'left') {
-        x = targetLeft - tipWidth - 6;
-        y = targetTop + targetHeight / 2 - tipHeight / 2;
-      } else if (place === 'right') {
-        x = targetLeft + targetWidth + 6;
-        y = targetTop + targetHeight / 2 - tipHeight / 2;
+      if (effect === 'float') {
+        if (this.state.place === 'top') {
+          offset.x = -(tipWidth / 2);
+          offset.y = -50;
+        } else if (this.state.place === 'bottom') {
+          offset.x = -(tipWidth / 2);
+          offset.y = 30;
+        } else if (this.state.place === 'left') {
+          offset.x = -(tipWidth + 15);
+          offset.y = -(tipHeight / 2);
+        } else if (this.state.place === 'right') {
+          offset.x = 10;
+          offset.y = -(tipHeight / 2);
+        }
       }
-      this.setState({
-        show: true,
-        x: this.state.x === 'NONE' ? x : this.state.x,
-        y: this.state.y === 'NONE' ? y : this.state.y
-      });
+      var style = {
+        left: this.state.x + offset.x + 'px',
+        top: this.state.y + offset.y + 'px'
+      };
+
+      var tooltipClass = (0, _classname['default'])('reactTooltip', { 'show': this.state.show }, { 'place-top': this.state.place === 'top' }, { 'place-bottom': this.state.place === 'bottom' }, { 'place-left': this.state.place === 'left' }, { 'place-right': this.state.place === 'right' }, { 'type-dark': this.state.type === 'dark' }, { 'type-success': this.state.type === 'success' }, { 'type-warning': this.state.type === 'warning' }, { 'type-error': this.state.type === 'error' }, { 'type-info': this.state.type === 'info' }, { 'type-light': this.state.type === 'light' });
+
+      return _React['default'].createElement(
+        'span',
+        { className: tooltipClass, style: style, 'data-id': 'tooltip' },
+        this.state.placeholder
+      );
     }
-  },
+  });
 
-  hideTooltip: function hideTooltip(e) {
-    this.setState({
-      show: false,
-      x: 'NONE',
-      y: 'NONE' });
-  },
-
-  componentDidMount: function componentDidMount() {
-    var targetArray = document.querySelectorAll('[data-tip]');
-    for (var i = 0; i < targetArray.length; i++) {
-      targetArray[i].addEventListener('mouseenter', this.showTooltip, false);
-      targetArray[i].addEventListener('mousemove', this.updateTooltip, false);
-      targetArray[i].addEventListener('mouseleave', this.hideTooltip, false);
-    }
-  },
-
-  componentWillUnmount: function componentWillUnmount() {
-    var targetArray = document.querySelectorAll('[data-tip]');
-    for (var i = 0; i < targetArray.length; i++) {
-      targetArray[i].removeEventListener('mouseenter', this.showTooltip);
-      targetArray[i].removeEventListener('mousemove', this.updateTooltip);
-      targetArray[i].removeEventListener('mouseleave', this.hideTooltip);
-    }
-  },
-
-  render: function render() {
-    var tipWidth = document.querySelector('[data-id=\'tooltip\']') ? document.querySelector('[data-id=\'tooltip\']').clientWidth : 0;
-    var tipHeight = document.querySelector('[data-id=\'tooltip\']') ? document.querySelector('[data-id=\'tooltip\']').clientHeight : 0;
-    var offset = { x: 0, y: 0 };
-    var effect = this.state.effect;
-
-    if (effect === 'float') {
-      if (this.state.place === 'top') {
-        offset.x = -(tipWidth / 2);
-        offset.y = -50;
-      } else if (this.state.place === 'bottom') {
-        offset.x = -(tipWidth / 2);
-        offset.y = 30;
-      } else if (this.state.place === 'left') {
-        offset.x = -(tipWidth + 15);
-        offset.y = -(tipHeight / 2);
-      } else if (this.state.place === 'right') {
-        offset.x = 10;
-        offset.y = -(tipHeight / 2);
-      }
-    }
-    var style = {
-      left: this.state.x + offset.x + 'px',
-      top: this.state.y + offset.y + 'px'
-    };
-
-    var tooltipClass = (0, _classnames2['default'])('reactTooltip', { 'show': this.state.show }, { 'place-top': this.state.place === 'top' }, { 'place-bottom': this.state.place === 'bottom' }, { 'place-left': this.state.place === 'left' }, { 'place-right': this.state.place === 'right' }, { 'type-dark': this.state.type === 'dark' }, { 'type-success': this.state.type === 'success' }, { 'type-warning': this.state.type === 'warning' }, { 'type-error': this.state.type === 'error' }, { 'type-info': this.state.type === 'info' }, { 'type-light': this.state.type === 'light' });
-
-    return _react2['default'].createElement(
-      'span',
-      { className: tooltipClass, style: style, 'data-id': 'tooltip' },
-      this.state.placeholder
-    );
-  }
+  module.exports = ReactTooltip;
 });
-
-exports['default'] = ReactTooltip;
-module.exports = exports['default'];

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/react-tooltip.js",
   "scripts": {
     "test": "jest",
-    "build:js": "babel src/js/index.jsx --out-file dist/react-tooltip.js",
+    "build:js": "babel --modules umd src/js/index.jsx --out-file dist/react-tooltip.js",
     "build:css": "node-sass --output-style compressed src/scss/style.scss dist/react-tooltip.min.css",
     "build": "npm run build:js & npm run build:css & cp src/scss/style.scss dist/react-tooltip.scss & cp src/scss/style.scss example/src/react-tooltip.scss & cp src/js/index.jsx example/src/react-tooltip.js"
   },


### PR DESCRIPTION
I had troubles using the module in non-browserify project because of the module definition. I believe using UMD will make it more universal.

The changes I made is in the [package.json file](https://github.com/wwayne/react-tooltip/compare/master...mgechev:master#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R8) and later I run `npm run build:js` in order to make the tooltip available in `dist`.