### PR TITLE
Allow inserting HTML raw code inside the span

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -249,7 +249,7 @@ export default class ReactTooltip extends Component {
     }
 
     return (
-      <span className={tooltipClass} data-id='tooltip'>{this.state.placeholder}</span>
+      <span className={tooltipClass} data-id='tooltip' dangerouslySetInnerHTML={{ __html: this.state.placeholder }}></span>
     )
   }
 


### PR DESCRIPTION
I see a lot of cases where you need to format your text inside the tooltip and html formatting is the closest to the react way I think. This way you can specify the tooltip text as raw html: "<p>This is a <strong>tooltip</strong></p>"