### PR TITLE
Fixes IE's lacking event constructor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,25 @@ export default class ReactTooltip extends Component {
    * Class method
    * @see ReactTooltip.hide() && ReactTooltup.rebuild()
    */
-  static hide () { window.dispatchEvent(new window.Event('__react_tooltip_hide_event')) }
-  static rebuild () { window.dispatchEvent(new window.Event('__react_tooltip_rebuild_event')) }
+  static hide () {
+    if (window.Event == "function") {
+      window.dispatchEvent(new window.Event('__react_tooltip_hide_event'))
+    } else {
+      var event = document.createEvent("Event");
+      event.initEvent("__react_tooltip_hide_event", false, true);
+      window.dispatchEvent(event);
+    }
+
+  }
+  static rebuild () {
+    if (window.Event == "function") {
+      window.dispatchEvent(new window.Event('__react_tooltip_rebuild_event'))
+    } else {
+      var event = document.createEvent("Event");
+      event.initEvent("__react_tooltip_rebuild_event", false, true);
+      window.dispatchEvent(event);
+    }
+  }
 
   static eventHideMark = `hide${Date.now()}`
   static eventRebuildMark = `rebuild${Date.now()}`


### PR DESCRIPTION
It seems like in IE an exception "Object doesn't support this action" is thrown, when using the hide and rebuild functions. This is due to the fact that IE didn't have a custom Event constructor before Edge.

For more information:
http://stackoverflow.com/questions/26596123/internet-explorer-9-10-11-ev
ent-constructor-doesnt-work