### PR TITLE
account for effect=solid in outside checks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -380,6 +380,11 @@ export default class ReactTooltip extends Component {
         x: 10,
         y: -(tipHeight / 2)
       }
+    } else {
+      offsetFromEffect.top = {x: 0, y: 0}
+      offsetFromEffect.bottom = {x: 0, y: 0}
+      offsetFromEffect.left = {x: 0, y: 0}
+      offsetFromEffect.right = {x: 0, y: 0}
     }
     let xPosition = 0
     let yPosition = 0


### PR DESCRIPTION
I missed the case where a solid tooltip would go out of bounds and the check will fail with `Cannot read property x of undefined`
I fixed by setting the default value of `offsetFromEffect` to be 0,0. Another option would be to remove the check for effect=="solid", but I'm not sure if that will have an adverse effect.