### PR TITLE
clearing delayShowLoop-Timeout when component will unmount

### DIFF
--- a/dist/react-tooltip.js
+++ b/dist/react-tooltip.js
@@ -148,6 +148,7 @@ var ReactTooltip = (function (_Component) {
   };
 
   ReactTooltip.prototype.componentWillUnmount = function componentWillUnmount() {
+    clearTimeout(this.delayShowLoop);
     this.unbindListener();
     this.removeScrollListener();
     this.mount = false;

--- a/src/index.js
+++ b/src/index.js
@@ -107,6 +107,7 @@ export default class ReactTooltip extends Component {
   }
 
   componentWillUnmount () {
+    clearTimeout(this.delayShowLoop)
     this.unbindListener()
     this.removeScrollListener()
     this.mount = false


### PR DESCRIPTION
else it will throw an error, that you can't setState of an unmounted component