### PR TITLE
Clear timeout when unmounting.

### DIFF
--- a/dist/react-tooltip.js
+++ b/dist/react-tooltip.js
@@ -154,6 +154,7 @@ var ReactTooltip = (function (_Component) {
     window.removeEventListener('__react_tooltip_hide_event', this.globalHide);
     window.removeEventListener('__react_tooltip_rebuild_event', this.globalRebuild);
     window.removeEventListener('resize', this.onWindowResize);
+    window.clearTimeout(this.delayShowLoop);
   };
 
   /* TODO: optimize, bind has been trigger too maany times */
@@ -337,7 +338,7 @@ var ReactTooltip = (function (_Component) {
     var delayShow = _state.delayShow;
     var show = _state.show;
 
-    clearTimeout(this.delayShowLoop);
+    window.clearTimeout(this.delayShowLoop);
 
     var delayTime = show ? 0 : parseInt(delayShow, 10);
     var eventTarget = e.currentTarget;
@@ -374,7 +375,7 @@ var ReactTooltip = (function (_Component) {
 
     var delayHide = this.state.delayHide;
 
-    clearTimeout(this.delayShowLoop);
+    window.clearTimeout(this.delayShowLoop);
     setTimeout(function () {
       _this3.setState({
         show: false

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "classnames": "^1.2.0",
-    "react-dom": "^0.14.0"
+    "react-dom": "0.14.*"
   },
   "devDependencies": {
     "babel": "^5.3.1",

--- a/src/index.js
+++ b/src/index.js
@@ -113,6 +113,7 @@ export default class ReactTooltip extends Component {
     window.removeEventListener('__react_tooltip_hide_event', this.globalHide)
     window.removeEventListener('__react_tooltip_rebuild_event', this.globalRebuild)
     window.removeEventListener('resize', this.onWindowResize)
+    window.clearTimeout(this.delayShowLoop)
   }
 
  /* TODO: optimize, bind has been trigger too maany times */
@@ -277,7 +278,7 @@ export default class ReactTooltip extends Component {
    */
   updateTooltip (e) {
     const {delayShow, show} = this.state
-    clearTimeout(this.delayShowLoop)
+    window.clearTimeout(this.delayShowLoop)
 
     const delayTime = show ? 0 : parseInt(delayShow, 10)
     const eventTarget = e.currentTarget
@@ -306,7 +307,7 @@ export default class ReactTooltip extends Component {
    */
   hideTooltip () {
     const {delayHide} = this.state
-    clearTimeout(this.delayShowLoop)
+    window.clearTimeout(this.delayShowLoop)
     setTimeout(() => {
       this.setState({
         show: false


### PR DESCRIPTION
This caused an exception when the tooltip was removed from the dom
before it was scheduled to show up.