### PR TITLE
Require the non-minified dist build in index

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 'use strict'
 
-module.exports = require('./dist/react-tooltip.min')
+module.exports = require('./dist/react-tooltip')


### PR DESCRIPTION
`index.js` was introduced in 502361992, and it imports the minified distribution build by default. This causes two problems:

1. It necessitates the addition of special workarounds to get the unminified build in development.
2. It causes webpack to break if users have the `noParse` option set for minified libraries, say with a pattern that matches `*.min.js.`. This option greatly enhances performance for webpack builds as it doesn't unpack and repack minified libraries, but it has a hard constraint that the unprocessed file **NOT** use `require()`.

Requiring the unminified build by default lets downstream tools handle bundling and minification in production, instead of forcing it by default.