### PR TITLE
Update peer dependencies to support react / react-dom >= 15.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "react-dom": "global:ReactDOM"
   },
   "peerDependencies": {
-    "react": ">=0.14.0",
-    "react-dom": "0.14.*"
+    "react": "^0.14.0 || ^15.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0"
   },
   "dependencies": {
     "classnames": "^1.2.0"


### PR DESCRIPTION
This will get rid of the nag message for npm v3 users and will allow npm v2 users on React 15 to continue using react-tooltip.