### PR TITLE
Added ability to change event propagation mode from default "bubble" to "capture"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -195,14 +195,16 @@ class ReactTooltip extends Component {
    * Used in customer event
    */
   checkStatus (e) {
-    e.stopPropagation()
+    if (this.props.eventPropagationMode === 'bubble') {
+      e.stopPropagation()
+    }
     if (this.state.show && e.currentTarget.getAttribute('currentItem') === 'true') {
       this.hideTooltip(e)
     } else {
       e.currentTarget.setAttribute('currentItem', 'true')
       /* when click other place, the tooltip should be removed */
       window.removeEventListener('click', this.bindClickListener)
-      window.addEventListener('click', this.bindClickListener, false)
+      window.addEventListener('click', this.bindClickListener, this.props.eventPropagationMode === 'capture')
 
       this.showTooltip(e)
       this.setUntargetItems(e.currentTarget)
@@ -635,7 +637,12 @@ ReactTooltip.propTypes = {
   delayHide: PropTypes.number,
   delayShow: PropTypes.number,
   event: PropTypes.any,
-  watchWindow: PropTypes.bool
+  watchWindow: PropTypes.bool,
+  eventPropagationMode: PropTypes.oneOf(['bubble', 'capture'])
+}
+
+ReactTooltip.defaultProps = {
+  eventPropagationMode: 'bubble'
 }
 
 /* export default not fit for standalone, it will exports {default:...} */


### PR DESCRIPTION
I had a scenario where the tooltip needed to be triggered on click. However, the trigger element is contained within a parent component that needed to handle the trigger click event as well. Unfortunately, the tooltip checkStatus method stopped click propagation in order to add a handler for outside click events that will close the tooltip.

I tried using a custom event to activate the tooltip on trigger click. This almost worked as the click event was propagating but unfortunately the event was bubbling _after_ the checkStatus outside handler was registered, so the tooltip was being hidden immediately.

The change I ultimately ended up making was to introduce a new prop to set the propagation mode to capture instead of bubble. This effectively disableds the e.stopPropagation call in checkStatus and changes the outside click handler to "capture" instead of "bubble", which allows the parent click event to be handled first and then displays the tooltip. And outside click events still close the tooltip. 

I was wary that changing the default bubble behavior might have unintended consequences for other people using this component, so the default event propagation mode will always be "bubble". But by setting the "eventPropagationMode" prop to "capture", you can change the default behavior.