### PR TITLE
Adding 'hideOnClick' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Check example:  [React-tooltip Test](http://wwayne.com/react-tooltip)
    delayHide	|   data-delay-hide  |  Number  |   | `<p data-tip="tooltip" data-delay-hide='1000'></p>` or `<ReactTooltip delayHide={1000} />`
     delayShow	|   data-delay-show  |  Number  |   | `<p data-tip="tooltip" data-delay-show='1000'></p>` or `<ReactTooltip delayShow={1000} />`
    border  |   data-border  |  Bool  |  true, false | Add one pixel white border
+   hideOnClick  |   hide-on-click  |  Bool  |  true, false | Hide the tooltip when target is clicked
 
 ### Using react component as tooltip
 Check the example [React-tooltip Test](http://wwayne.com/react-tooltip)

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,7 @@ class ReactTooltip extends Component {
       html: false,
       delayHide: 0,
       delayShow: 0,
+      hideOnClick: false,
       event: props.event || null,
       isCapture: props.isCapture || false
     }
@@ -135,6 +136,11 @@ class ReactTooltip extends Component {
 
         targetArray[i].removeEventListener('mouseleave', this.hideTooltip)
         targetArray[i].addEventListener('mouseleave', this.hideTooltip, false)
+        
+        if(this.state.hideOnClick) {
+          targetArray[i].removeEventListener('click', this.hideTooltip)
+          targetArray[i].addEventListener('click', this.hideTooltip, false)
+        }
       }
     }
   }
@@ -151,6 +157,10 @@ class ReactTooltip extends Component {
         targetArray[i].removeEventListener('mouseenter', this.showTooltip)
         targetArray[i].removeEventListener('mousemove', this.updateTooltip)
         targetArray[i].removeEventListener('mouseleave', this.hideTooltip)
+        
+        if(this.state.hideOnClick) {
+          targetArray[i].removeEventListener('click', this.hideTooltip)
+        }
       }
     }
   }
@@ -269,6 +279,7 @@ class ReactTooltip extends Component {
       delayShow: e.currentTarget.getAttribute('data-delay-show') ? e.currentTarget.getAttribute('data-delay-show') : (this.props.delayShow ? this.props.delayShow : 0),
       delayHide: e.currentTarget.getAttribute('data-delay-hide') ? e.currentTarget.getAttribute('data-delay-hide') : (this.props.delayHide ? this.props.delayHide : 0),
       border: e.currentTarget.getAttribute('data-border') ? (e.currentTarget.getAttribute('data-border') === 'true') : (this.props.border ? this.props.border : false),
+      hideOnClick: e.currentTarget.hasAttribute('hide-on-click') ? !! e.currentTarget.getAttribute('hide-on-click') : !! this.props.hideOnClick,
       extraClass,
       multiline
     })


### PR DESCRIPTION
This adds an option to hide the tooltip when the target element is clicked.

In my app, I have a tooltip on a button that is moved / hides itself after it is clicked. When the button is clicked, the button disappears, but the tooltip stays present until I mouse over something else that has a tooltip (this is because the element has disappeared, and therefore can't trigger the `mouseleave` event). I fixed this bug by adding this option to hide the tooltip when the target element is clicked.