### PR TITLE
Ensure data-html is converted to bool type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -267,7 +267,7 @@ class ReactTooltip extends Component {
       type: e.currentTarget.getAttribute('data-type') || this.props.type || 'dark',
       effect: e.currentTarget.getAttribute('data-effect') || this.props.effect || 'float',
       offset: e.currentTarget.getAttribute('data-offset') || this.props.offset || {},
-      html: e.currentTarget.getAttribute('data-html') || this.props.html || false,
+      html: e.currentTarget.getAttribute('data-html') === 'true' || this.props.html || false,
       delayShow: e.currentTarget.getAttribute('data-delay-show') || this.props.delayShow || 0,
       delayHide: e.currentTarget.getAttribute('data-delay-hide') || this.props.delayHide || 0,
       border: e.currentTarget.getAttribute('data-border') === 'true' || this.props.border || false,


### PR DESCRIPTION
When using data-html attribute, this value was assigned to the html state attribute without ensuring the bool type, so it was being assigned as a string "true" or "false".

Later, this value was accessed with the code:
`if (html) {`
this was evaluating always to true and causing the content to not being encoded.

Applied code to ensure bool value, similar to the code applied for the data-border attribute.