### PR TITLE
Feature: Support custom attribute for tooltip content

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Global|Specific	|Type	|Values  |  Description
  event |   data-event  |  String  |  e.g. click | custom event to trigger tooltip
  eventOff |   data-event-off  |  String  |  e.g. click | custom event to hide tooltip (only makes effect after setting event attribute)
  globalEventOff | | 'string'| e.g. click| global event to hide tooltip (global only)
- isCapture | data-iscapture | Bool | true, false | when set to ture, custom event's propagation mode will be capture
+ isCapture | data-iscapture | Bool | true, false | when set to true, custom event's propagation mode will be capture
  offset	|   data-offset  |  Object  |  top, right, bottom, left | `data-offset="{'top': 10, 'left': 10}"` for specific and `offset={{top: 10, left: 10}}` for global
 multiline	|   data-multiline  |  Bool  |  true, false | support `<br>`, `<br />` to make multiline
 class	|   data-class  |  String  |   | extra custom class, can use !important to overwrite react-tooltip's default class

--- a/README.md
+++ b/README.md
@@ -61,12 +61,13 @@ class	|   data-class  |  String  |   | extra custom class, can use !important to
  delayHide	|   data-delay-hide  |  Number  |   | `<p data-tip="tooltip" data-delay-hide='1000'></p>` or `<ReactTooltip delayHide={1000} />`
  delayShow	|   data-delay-show  |  Number  |   | `<p data-tip="tooltip" data-delay-show='1000'></p>` or `<ReactTooltip delayShow={1000} />`
  border  |   data-border  |  Bool  |  true, false | Add one pixel white border
+ handle	|    |  String  |  e.g data-tip | Use a custom attribute to locate the tooltip's contents
 
 ## Using react component as tooltip
 Check the example [React-tooltip Test](http://wwayne.com/react-tooltip)
 
 ##### Note:
-1. **data-tip** is necessary, because `<ReactTooltip />` find tooltip via this attribute
+1. **data-tip** is necessary (or the custom `handle` set), because `<ReactTooltip />` find tooltip via this attribute
 2. **data-for** correspond to the **id** of `<ReactTooltip />`
 3. When using react component as tooltip, you can have many `<ReactTooltip />` in a page but they should have different **id**
 

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,8 @@ class ReactTooltip extends Component {
     eventOff: PropTypes.string,
     watchWindow: PropTypes.bool,
     isCapture: PropTypes.bool,
-    globalEventOff: PropTypes.string
+    globalEventOff: PropTypes.string,
+    handle: PropTypes.string
   }
 
   constructor (props) {
@@ -57,7 +58,8 @@ class ReactTooltip extends Component {
       event: props.event || null,
       eventOff: props.eventOff || null,
       currentEvent: null, // Current mouse event
-      currentTarget: null // Current target of mouse event
+      currentTarget: null, // Current target of mouse event
+      handle: props.handle || 'data-tip' // Custom attribute for tooltip
     }
 
     this.mount = true
@@ -89,9 +91,9 @@ class ReactTooltip extends Component {
     let targetArray
 
     if (!id) {
-      targetArray = document.querySelectorAll('[data-tip]:not([data-for])')
+      targetArray = document.querySelectorAll(`[${this.state.handle}]:not([data-for])`)
     } else {
-      targetArray = document.querySelectorAll(`[data-tip][data-for="${id}"]`)
+      targetArray = document.querySelectorAll(`[${this.state.handle}][data-for="${id}"]`)
     }
 
     // targetArray is a NodeList, convert it to a real array
@@ -166,7 +168,7 @@ class ReactTooltip extends Component {
     // Get the tooltip content
     // calculate in this phrase so that tip width height can be detected
     const {children, multiline} = this.props
-    const originTooltip = e.currentTarget.getAttribute('data-tip')
+    const originTooltip = e.currentTarget.getAttribute(this.state.handle)
     const isMultiline = e.currentTarget.getAttribute('data-multiline') || multiline || false
     const placeholder = getTipContent(originTooltip, children, isMultiline)
 


### PR DESCRIPTION
#### What does this PR do?
 - It adds an extra prop to the component to receive a custom handle, used to target the tooltip content i.e. custom props can be used in place of `data-tip`.
 - The prop is called `handle` and assumes value `'data-tip'` as the default value when the prop is not used.