### PR TITLE
add type dark to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Check example:  [React-tooltip Test](http://wwayne.com/react-tooltip)
 Global|Specific	|Type	|Values  |  Description
 |:---|:---|:---|:---|:----
  place	|   data-place  |  String  |  top, right, bottom, left | placement
- type	|   data-type  |  String  |  success, warning, error, info, light | theme
+ type	|   data-type  |  String  |  success, warning, error, info, light, dark | theme
  effect|   data-effect  |  String  |  float, solid | behaviour of tooltip
  event |   data-event  |  String  |  e.g. click | custom event to trigger tooltip
  eventOff |   data-event-off  |  String  |  e.g. click | custom event to hide tooltip (only makes effect after setting event attribute)


### PR DESCRIPTION
-I wanted a dark tooltip, but didn't find what I wanted after trying all the 'type' options listed in the readme, so started going through index.scss to see how I was going to manipulate the css and there was what I was searching for all along!  type: dark   Figured I'd just add it to the readme real quick