### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,33 @@
+{
+  "name": "react-tooltip",
+  "description": "react tooltip component",
+  "main": "standalone/react-tooltip.js",
+  "moduleType": [
+    "globals",
+    "amd",
+    "node"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "bin",
+    "example"
+  ],
+  "keywords": [
+    "react",
+    "react-component",
+    "tooltip",
+    "react-tooltip"
+  ],
+  "authors": [
+    "wwayne"
+  ],
+  "homepage": "https://github.com/wwayne/react-tooltip",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wwayne/react-tooltip"
+  },
+  "dependencies": {
+    "react": "^0.14.0 || ^15.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0"
+  }
+}


### PR DESCRIPTION
Fixes #97 

- Created `bower.json` in project root.
- `main` is set to `standalone/react-tooltip.js` to allow tools like [wiredep](https://github.com/taptapship/wiredep) to automatically locate the correct distribution file
- React and ReactDOM moved to `dependencies` as Bower does not have `peerDependencies`