### PR TITLE
Remove react-dom from Bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,6 @@
     "url": "https://github.com/wwayne/react-tooltip"
   },
   "dependencies": {
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.0.0"
   }
 }


### PR DESCRIPTION
Hey, I noticed a mistake in my earlier PR about adding a bower.json (https://github.com/wwayne/react-tooltip/pull/179): `react-dom` is not a proper Bower dependency and the `react` package instead comes with `react-dom` properly configured in its `main`: https://github.com/reactjs/react-bower/blob/master/bower.json#L3

Sorry about the confusion, but here a fix PR.