### PR TITLE
Fixes IE bug when empty data-tip.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -312,7 +312,8 @@ class ReactTooltip extends Component {
     const resetState = () => {
       const isVisible = this.state.show
       this.setState({
-        show: false
+        show: false,
+        placeholder: ''
       }, () => {
         this.removeScrollListener()
         if (isVisible && afterHide) afterHide()


### PR DESCRIPTION
How to see the bug:

1. Create two elements with data-tip attribute
2. Add content to one of the data-tip attributes, and have en empty string in the other
3. Hover over the one with content
4. Exit the element
5. Hover over the one without content

Result:
An empty tooltip will appear in IE 10 and 11 (probably others as well)
If exit the element without content, then enter again, all is ok.

Probable reason:
Since the content of the tooltip is not reset after exit, some logic probably thinks there is content, even though the new item does not have content.