### PR TITLE
Use node parent when calculating offset

### DIFF
--- a/example/src/index.js
+++ b/example/src/index.js
@@ -45,7 +45,7 @@ const Test = React.createClass({
       <div>
         <section className='tooltip-example'>
           <h4 className='title'>React Tooltip</h4>
-          <div className='demonstration'>
+          <div style={{marginTop: 40, transform: "translateY(-20px)"}} className='demonstration'>
             <a data-for='main' data-tip="Hello<br />multiline<br />tooltip">
                ◕‿‿◕
             </a>
@@ -83,7 +83,9 @@ const Test = React.createClass({
               </div>
             </pre>
           </div>
-          <ReactTooltip id='main' place={place} type={type} effect={effect} multiline={true}/>
+          <div style={{transform: "translateY(40px)"}}>
+            <ReactTooltip id='main' place={place} type={type} effect={effect} multiline={true}/>
+          </div>
         </section>
         <section className="advance">
           <div className="section">

--- a/src/utils/getPosition.js
+++ b/src/utils/getPosition.js
@@ -24,7 +24,7 @@ export default function (e, target, node, place, effect, offset, countTransform)
   const windowWidth = window.innerWidth
   const windowHeight = window.innerHeight
 
-  const {parentTop, parentLeft} = countTransform && getParent(target, countTransform) || {parentTop: 0, parentLeft: 0}
+  const {parentTop, parentLeft} = countTransform && getParent(node, countTransform) || {parentTop: 0, parentLeft: 0}
 
   // Get the edge offset of the tooltip
   const getTipOffsetLeft = (place) => {


### PR DESCRIPTION
Hi,

I added some transforms to the examples as a quick way to see it's working. When calculating the tooltip position, the parent of the node should be taken as an offset, and not the target. 

This is not a complete solution, because the node can be within multiple chain-of-parents with transforms (which have to be accumulated), but at least now if the target is inside a parent with transform the tooltip is in the right position.