### PR TITLE
Fix fire of global show event for IE

### DIFF
--- a/src/decorators/staticMethods.js
+++ b/src/decorators/staticMethods.js
@@ -12,7 +12,8 @@ const dispatchGlobalEvent = (eventName, opts) => {
     event = new window.CustomEvent(eventName, { detail: opts })
   } else {
     event = document.createEvent('Event')
-    event.initEvent(eventName, false, true, opts)
+    event.initEvent(eventName, false, true)
+    event.detail = opts
   }
 
   window.dispatchEvent(event)


### PR DESCRIPTION
For IE create new Event object and set details separately because initEvent doesn't support this and we expect lately to have detail property on event object.