### PR TITLE
Replaced Object.keys(...) by Object.getOwnPropertyNames(...)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,7 @@ class ReactTooltip extends Component {
 
     // targetArray is a NodeList, convert it to a real array
     // I hope I can use Object.values...
-    return Object.keys(targetArray).filter(key => key !== 'length').map(key => {
+    return Object.getOwnPropertyNames(targetArray).map(key => {
       return targetArray[key]
     })
   }


### PR DESCRIPTION
Hi,

We replaced Object.keys(...) by Object.getOwnPropertyNames(...) because it's safer and has same browser support. 

It's safer because it will only retrieves index of the NodeList, and not methods. it is no longer needed to filter the output.

We did this because we encountered a problem in regard with this.

Best regards,

Gauthier JACQUES 