### PR TITLE
escape backslash in getTargetArray method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -150,7 +150,8 @@ class ReactTooltip extends Component {
     if (!id) {
       targetArray = document.querySelectorAll('[data-tip]:not([data-for])')
     } else {
-      targetArray = document.querySelectorAll(`[data-tip][data-for="${id}"]`)
+      const escaped = id.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+      targetArray = document.querySelectorAll(`[data-tip][data-for="${escaped}"]`)
     }
     // targetArray is a NodeList, convert it to a real array
     return nodeListToArray(targetArray)


### PR DESCRIPTION
it's a rare case, but if `data-tip` contains backslash, `getTargetArray` or more specifically `querySelectorAll` won't find the element