### PR TITLE
Allow to use custom callback on globalEventOff events

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Global|Specific	|Type	|Values  |  Description
  event |   data-event  |  String  |  e.g. click | custom event to trigger tooltip
  eventOff |   data-event-off  |  String  |  e.g. click | custom event to hide tooltip (only makes effect after setting event attribute)
  globalEventOff | | String| e.g. click| global event to hide tooltip (global only)
+ globalEventOffCallback | | Func| (hideTooltip, event) => hideTooltip(event)| global event callback to hide tooltip. Works only if globalEventOff specified
  isCapture | data-iscapture | Bool | true, false | when set to true, custom event's propagation mode will be capture
  offset	|   data-offset  |  Object  |  top, right, bottom, left | `data-offset="{'top': 10, 'left': 10}"` for specific and `offset={{top: 10, left: 10}}` for global
 multiline	|   data-multiline  |  Bool  |  true, false | support `<br>`, `<br />` to make multiline

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -4,6 +4,12 @@ import React from 'react'
 import {render, findDOMNode} from 'react-dom'
 import ReactTooltip from '../../src'
 
+const customGlobalEventOffCallback = function(hideTooltip, event, hasTarget) {
+  if (event.keyCode === 27) {
+    hideTooltip(event, hasTarget)
+  }
+}
+
 const Test = React.createClass({
 
   getInitialState () {
@@ -172,6 +178,25 @@ const Test = React.createClass({
               <div>
                 <p>{"<a data-tip='custom show and hide' data-event='click' data-event-off='dblclick'>( •̀д•́)</a>\n" +
                 "<ReactTooltip/>"}</p>
+              </div>
+            </pre>
+          </div>
+          <div className="section">
+            <div className="example-jsx">
+              <div className="side">
+                <a data-for='custom-off-event-callback' ref='target' data-tip='custom hide callback on escape'>( •̀д•́)</a>
+                <ReactTooltip id='custom-off-event-callback' globalEventOff='keyup' globalEventOffCallback={customGlobalEventOffCallback}/>
+              </div>
+            </div>
+            <br />
+            <pre className='example-pre'>
+              <div>
+                <p>{"<a data-tip='custom show' data-event='click focus'>( •̀д•́)</a>\n" +
+                "\n" +
+                "const handler = function(hideTooltip, event) {\n" +
+                " if (event.keyCode === 27) hideTooltip(event)\n" +
+                "}\n" +
+                "<ReactTooltip globalEventOff='keyup' globalEventOffCallback={handler} />"}</p>
               </div>
             </pre>
           </div>

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,7 @@ class ReactTooltip extends Component {
     watchWindow: PropTypes.bool,
     isCapture: PropTypes.bool,
     globalEventOff: PropTypes.string,
+    globalEventOffCallback: PropTypes.func,
     getContent: PropTypes.any,
     afterShow: PropTypes.func,
     afterHide: PropTypes.func,
@@ -156,7 +157,7 @@ class ReactTooltip extends Component {
    * These listeners used to trigger showing or hiding the tooltip
    */
   bindListener () {
-    const {id, globalEventOff} = this.props
+    const {id, globalEventOff, globalEventOffCallback} = this.props
     let targetArray = this.getTargetArray(id)
 
     targetArray.forEach(target => {
@@ -180,8 +181,13 @@ class ReactTooltip extends Component {
 
     // Global event to hide tooltip
     if (globalEventOff) {
-      window.removeEventListener(globalEventOff, this.hideTooltip)
-      window.addEventListener(globalEventOff, this.hideTooltip, false)
+      if (globalEventOffCallback) {
+        window.removeEventListener(globalEventOff, globalEventOffCallback.bind(this, this.hideTooltip))
+        window.addEventListener(globalEventOff, globalEventOffCallback.bind(this, this.hideTooltip), false)
+      } else {
+        window.removeEventListener(globalEventOff, this.hideTooltip)
+        window.addEventListener(globalEventOff, this.hideTooltip, false)
+      }
     }
   }
 
@@ -189,14 +195,17 @@ class ReactTooltip extends Component {
    * Unbind listeners on target elements
    */
   unbindListener () {
-    const {id, globalEventOff} = this.props
+    const {id, globalEventOff, globalEventOffCallback} = this.props
     const targetArray = this.getTargetArray(id)
     targetArray.forEach(target => {
       this.unbindBasicListener(target)
       if (this.isCustomEvent(target)) this.customUnbindListener(target)
     })
 
-    if (globalEventOff) window.removeEventListener(globalEventOff, this.hideTooltip)
+    if (globalEventOff) {
+      if (globalEventOffCallback) window.removeEventListener(globalEventOff, globalEventOffCallback.bind(this, this.hideTooltip))
+      else window.removeEventListener(globalEventOff, this.hideTooltip)
+    }
   }
 
   /**


### PR DESCRIPTION
Currently there is no way to fire globalEventOff events conditionally – for example, to hide tooltip only if Escape key is pressed. In this PR I added globalEventOffCallback function property, which first argument is original hideTooltip function, second argument is original event, so it become possible to hide tooltip only when it's really necessary:

```
const customCallback = function(hideTooltip, event, hasTarget) {
    if (event.keyCode === 27) hideTooltip(event, hasTarget)
}
...
<ReactTooltip globalEventOff="keyup" globalEventOffCallback={customCallback} />
```