### PR TITLE
Fix delayHide issue #246

### DIFF
--- a/src/decorators/getEffect.js
+++ b/src/decorators/getEffect.js
@@ -1,0 +1,11 @@
+/**
+ * Util method to get effect
+ */
+
+export default function (target) {
+  target.prototype.getEffect = function (currentTarget) {
+    const dataEffect = currentTarget.getAttribute('data-effect')
+    return dataEffect || this.props.effect || 'float'
+  }
+}
+

--- a/src/index.js
+++ b/src/index.js
@@ -250,6 +250,9 @@ class ReactTooltip extends Component {
       scrollHide = this.props.scrollHide
     }
 
+    // To prevent previously created timers from triggering
+    this.clearTimer()
+
     this.setState({
       placeholder,
       isEmptyTip,

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import staticMethods from './decorators/staticMethods'
 import windowListener from './decorators/windowListener'
 import customEvent from './decorators/customEvent'
 import isCapture from './decorators/isCapture'
+import getEffect from './decorators/getEffect'
 
 /* Utils */
 import getPosition from './utils/getPosition'
@@ -18,7 +19,7 @@ import { parseAria } from './utils/aria'
 /* CSS */
 import cssStyle from './style'
 
-@staticMethods @windowListener @customEvent @isCapture
+@staticMethods @windowListener @customEvent @isCapture @getEffect
 class ReactTooltip extends Component {
 
   static propTypes = {
@@ -161,6 +162,7 @@ class ReactTooltip extends Component {
 
     targetArray.forEach(target => {
       const isCaptureMode = this.isCapture(target)
+      const effect = this.getEffect(target)
       if (target.getAttribute('currentItem') === null) {
         target.setAttribute('currentItem', 'false')
       }
@@ -172,7 +174,7 @@ class ReactTooltip extends Component {
       }
 
       target.addEventListener('mouseenter', this.showTooltip, isCaptureMode)
-      if (this.state.effect === 'float') {
+      if (effect === 'float') {
         target.addEventListener('mousemove', this.updateTooltip, isCaptureMode)
       }
       target.addEventListener('mouseleave', this.hideTooltip, isCaptureMode)
@@ -258,7 +260,7 @@ class ReactTooltip extends Component {
       isEmptyTip,
       place: e.currentTarget.getAttribute('data-place') || this.props.place || 'top',
       type: e.currentTarget.getAttribute('data-type') || this.props.type || 'dark',
-      effect: switchToSolid && 'solid' || e.currentTarget.getAttribute('data-effect') || this.props.effect || 'float',
+      effect: switchToSolid && 'solid' || this.getEffect(e.currentTarget),
       offset: e.currentTarget.getAttribute('data-offset') || this.props.offset || {},
       html: e.currentTarget.getAttribute('data-html')
         ? e.currentTarget.getAttribute('data-html') === 'true'


### PR DESCRIPTION
# Description 
The following text assumes that reader has read description of issue #246.

At first, I've just added `this.cleanTimer()` in `showTooltip` method.
Problem described in #246 has completely gone. 

But it's reasonable to ask: why behavior is different after `ReactTooltip.rebuild()`?
It was caused by invalid effect detection in `bindListeners` method. 

I think, this should be considered as a bug:
![effect](https://cloud.githubusercontent.com/assets/3264579/22406212/076e0de4-e660-11e6-9a79-ddabed7a6e12.gif)

In the example above, there are one `<ReactTooltip />` component with default setup, both buttons SampleText(1|2) attached to this `ReactTooltip`, `data-effect` of the second button has been set to `solid`.

I haven't get an idea why `isCapture` is implemented as decorator, but I've followed the same way and have added `getEffect` decorator. I wonder what you think about it.

# Tests
Test stand still available at http://hmnid.ru:8090/ . Test stand for `effect` issue available at http://hmnid.ru:8090/effect.html

Demo with fixed react-tooltip available at http://hmnid:8091/ and http://hmnid.ru:8091/effect.html respectively.

Sources of demos available at https://github.com/huumanoid/react-tooltip-delayhide-issue-test