### PR TITLE
Feature: listen body events

### DIFF
--- a/src/decorators/bodyMode.js
+++ b/src/decorators/bodyMode.js
@@ -98,7 +98,7 @@ export default function (target) {
 
     const listeners = this.bodyModeListeners
     for (const event in listeners) {
-      body.removeEventListener(event, listeners(event))
+      body.removeEventListener(event, listeners[event])
     }
   }
 }

--- a/src/decorators/bodyMode.js
+++ b/src/decorators/bodyMode.js
@@ -59,7 +59,8 @@ export default function (target) {
 
   target.prototype.bindBodyListener = function (targetArray) {
     const { id } = this.props
-    const { event, eventOff } = this.state
+    const { event, eventOff, possibleCustomEvents,
+      possibleCustomEventsOff } = this.state
     const body = getBody()
 
     const customEvents = findCustomEvents(targetArray, 'data-event')
@@ -67,8 +68,8 @@ export default function (target) {
 
     if (event != null) customEvents[event] = true
     if (eventOff != null) customEventsOff[eventOff] = true
-    for (const event of this.state.possibleCustomEvents) customEvents[event] = true
-    for (const event of this.state.possibleCustomEventsOff) customEventsOff[event] = true
+    possibleCustomEvents.split(' ').forEach(event => customEvents[event] = true)
+    possibleCustomEventsOff.split(' ').forEach(event => customEventsOff[event] = true)
 
     this.unbindBodyListener(body)
 

--- a/src/decorators/bodyMode.js
+++ b/src/decorators/bodyMode.js
@@ -64,6 +64,8 @@ export default function (target) {
 
     if (event != null) customEvents[event] = true
     if (eventOff != null) customEventsOff[eventOff] = true
+    for (const event of this.state.possibleCustomEvents) customEvents[event] = true
+    for (const event of this.state.possibleCustomEventsOff) customEventsOff[event] = true
 
     this.unbindBodyListener(body)
 

--- a/src/decorators/bodyMode.js
+++ b/src/decorators/bodyMode.js
@@ -54,7 +54,7 @@ const getBody = () => document.getElementsByTagName('body')[0]
 
 export default function (target) {
   target.prototype.isBodyMode = function () {
-    return this.props.bodyMode
+    return !!this.props.bodyMode
   }
 
   target.prototype.bindBodyListener = function (targetArray) {

--- a/src/decorators/bodyMode.js
+++ b/src/decorators/bodyMode.js
@@ -57,10 +57,9 @@ export default function (target) {
     return this.props.bodyMode
   }
 
-  target.prototype.bindBodyListener = function () {
+  target.prototype.bindBodyListener = function (targetArray) {
     const { id } = this.props
     const { event, eventOff } = this.state
-    const targetArray = this.getTargetArray(id)
     const body = getBody()
 
     const customEvents = findCustomEvents(targetArray, 'data-event')

--- a/src/decorators/bodyMode.js
+++ b/src/decorators/bodyMode.js
@@ -1,0 +1,57 @@
+/**
+ * Util method to get effect
+ */
+
+export default function (target) {
+  const clone = (e) => {
+    const copy = {}
+    for (const key in e) {
+      copy[key] = e[key]
+    }
+    return copy
+  }
+
+  const bodyListener = function (callback, respectEffect, e) {
+    const {id} = this.props
+
+    const tip = e.target.dataset.tip
+    const _for = e.target.dataset.for
+
+    const target = e.target
+
+    if (tip != null
+      && (!respectEffect || this.getEffect(target) === 'float')
+      && (
+      (id == null && _for == null)
+        || (id != null && _for === id)
+    )) {
+      const x = clone(e)
+      x.currentTarget = target
+      callback(x)
+    }
+  }
+
+  target.prototype.bindBodyListener = function () {
+    const body = document.getElementsByTagName('body')[0]
+
+    const listeners = this.bodyModeListeners = {
+      'mouseover': bodyListener.bind(this, this.showTooltip, false),
+      'mousemove': bodyListener.bind(this, this.updateTooltip, true),
+      'mouseout': bodyListener.bind(this, this.hideTooltip, false)
+    }
+    for (const event in listeners) {
+      body.addEventListener(event, listeners[event])
+    }
+  }
+
+  target.prototype.unbindBodyListener = function () {
+    const body = document.getElementsByTagName('body')[0]
+
+    const listeners = this.bodyModeListeners
+    for (const event in listeners) {
+      body.removeEventListener(event, listeners(event))
+    }
+  }
+}
+
+

--- a/src/decorators/bodyMode.js
+++ b/src/decorators/bodyMode.js
@@ -3,6 +3,10 @@
  */
 
 export default function (target) {
+  target.prototype.isBodyMode = function () {
+    return this.props.bodyMode
+  }
+
   const clone = (e) => {
     const copy = {}
     for (const key in e) {

--- a/src/decorators/bodyMode.js
+++ b/src/decorators/bodyMode.js
@@ -60,9 +60,11 @@ export default function (target) {
     const customEvents = findCustomEvents(targetArray, 'data-event')
     const customEventsOff = findCustomEvents(targetArray, 'data-event-off')
 
+    this.unbindBodyListener(body)
+
     const listeners = this.bodyModeListeners = {
       'mouseover': bodyListener.bind(this, this.showTooltip, {}),
-      'mousemove': bodyListener.bind(this, this.updateTooltip, {respectEffect: true}),
+      'mousemove': bodyListener.bind(this, this.updateTooltip, { respectEffect: true }),
       'mouseout': bodyListener.bind(this, this.hideTooltip, {})
     }
 
@@ -80,8 +82,8 @@ export default function (target) {
     }
   }
 
-  target.prototype.unbindBodyListener = function () {
-    const body = document.getElementsByTagName('body')[0]
+  target.prototype.unbindBodyListener = function (body) {
+    body = body || document.getElementsByTagName('body')[0]
 
     const listeners = this.bodyModeListeners
     for (const event in listeners) {

--- a/src/decorators/bodyMode.js
+++ b/src/decorators/bodyMode.js
@@ -19,8 +19,8 @@ const bodyListener = function (callback, options, e) {
   const {respectEffect = false, customEvent = false} = options
   const {id} = this.props
 
-  const tip = e.target.dataset.tip
-  const _for = e.target.dataset.for
+  const tip = e.target.getAttribute('data-tip') || null
+  const forId = e.target.getAttribute('data-for') || null
 
   const target = e.target
   if (this.isCustomEvent(target) && !customEvent) {
@@ -28,7 +28,7 @@ const bodyListener = function (callback, options, e) {
   }
 
   const isTargetBelongsToTooltip =
-    (id == null && _for == null) || (id != null && _for === id)
+    (id == null && forId == null) || forId === id
 
   if (tip != null &&
     (!respectEffect || this.getEffect(target) === 'float') &&

--- a/src/decorators/bodyMode.js
+++ b/src/decorators/bodyMode.js
@@ -8,18 +8,21 @@ export default function (target) {
     return this.props.bodyMode
   }
 
-  const clone = (e) => {
-    const copy = {}
+  const makeProxy = (e) => {
+    const proxy = {}
     for (const key in e) {
-      copy[key] = e[key]
+      if (typeof e[key] === 'function') {
+        proxy[key] = e[key].bind(e)
+      } else {
+        proxy[key] = e[key]
+      }
     }
-    return copy
+    return proxy
   }
 
   const bodyListener = function (callback, options, e) {
     const {respectEffect = false, customEvent = false} = options
     const {id} = this.props
-    const isCapture = this.isCapture(e.currentTarget)
 
     const tip = e.target.dataset.tip
     const _for = e.target.dataset.for
@@ -33,11 +36,9 @@ export default function (target) {
       (!respectEffect || this.getEffect(target) === 'float') &&
       ((id == null && _for == null) || (id != null && _for === id))
     ) {
-      const x = clone(e)
-      x.currentTarget = target
-      x.stopPropagation = () => {}
-      if (customEvent && !isCapture) e.stopPropagation()
-      callback(x)
+      const proxy = makeProxy(e)
+      proxy.currentTarget = target
+      callback(proxy)
     }
   }
 

--- a/src/decorators/bodyMode.js
+++ b/src/decorators/bodyMode.js
@@ -54,12 +54,16 @@ export default function (target) {
 
   target.prototype.bindBodyListener = function () {
     const { id } = this.props
+    const { event, eventOff } = this.state
     const body = document.getElementsByTagName('body')[0]
 
     const targetArray = this.getTargetArray(id)
 
     const customEvents = findCustomEvents(targetArray, 'data-event')
     const customEventsOff = findCustomEvents(targetArray, 'data-event-off')
+
+    if (event != null) customEvents[event] = true
+    if (eventOff != null) customEventsOff[eventOff] = true
 
     this.unbindBodyListener(body)
 
@@ -71,7 +75,6 @@ export default function (target) {
 
     for (const event in customEvents) {
       listeners[event] = bodyListener.bind(this, (e) => {
-        const { eventOff } = this.state
         checkStatus.call(this, e.currentTarget.getAttribute('data-event-off') || eventOff, e)
       }, { customEvent: true })
     }

--- a/src/decorators/bodyMode.js
+++ b/src/decorators/bodyMode.js
@@ -1,9 +1,11 @@
 /**
  * Util method to get effect
  */
+import {checkStatus} from './customEvent'
 
 export default function (target) {
   target.prototype.isBodyMode = function () {
+    return true
     return this.props.bodyMode
   }
 
@@ -15,13 +17,18 @@ export default function (target) {
     return copy
   }
 
-  const bodyListener = function (callback, respectEffect, e) {
+  const bodyListener = function (callback, options, e) {
+    const {respectEffect = false, customEvent = false} = options
     const {id} = this.props
+    const isCapture = this.isCapture(e.currentTarget)
 
     const tip = e.target.dataset.tip
     const _for = e.target.dataset.for
 
     const target = e.target
+    if (!!target.getAttribute('data-event') && !customEvent) {
+      return
+    }
 
     if (tip != null
       && (!respectEffect || this.getEffect(target) === 'float')
@@ -31,17 +38,45 @@ export default function (target) {
     )) {
       const x = clone(e)
       x.currentTarget = target
+      x.stopPropagation = () => {}
+      if (!isCapture) e.stopPropagation()
       callback(x)
     }
   }
 
+  const findCustomEvents = (targetArray, dataAttribute) => {
+    const events = {}
+    targetArray.forEach(target => {
+      const event = target.getAttribute(dataAttribute)
+      if (event) event.split(' ').forEach(event => events[event] = true)
+    })
+
+    return events
+  }
+
   target.prototype.bindBodyListener = function () {
+    const { id } = this.props
     const body = document.getElementsByTagName('body')[0]
 
+    const targetArray = this.getTargetArray(id)
+
+    const customEvents = findCustomEvents(targetArray, 'data-event')
+    const customEventsOff = findCustomEvents(targetArray, 'data-event-off')
+
     const listeners = this.bodyModeListeners = {
-      'mouseover': bodyListener.bind(this, this.showTooltip, false),
-      'mousemove': bodyListener.bind(this, this.updateTooltip, true),
-      'mouseout': bodyListener.bind(this, this.hideTooltip, false)
+      'mouseover': bodyListener.bind(this, this.showTooltip, {}),
+      'mousemove': bodyListener.bind(this, this.updateTooltip, {respectEffect: true}),
+      'mouseout': bodyListener.bind(this, this.hideTooltip, {})
+    }
+
+    for (const event in customEvents) {
+      listeners[event] = bodyListener.bind(this, (e) => {
+        const { eventOff } = this.state
+        checkStatus.call(this, e.currentTarget.getAttribute('data-event-off') || eventOff, e)
+      }, { customEvent: true })
+    }
+    for (const event in customEventsOff) {
+      listeners[event] = bodyListener.bind(this, this.hideTooltip, { customEvent: true })
     }
     for (const event in listeners) {
       body.addEventListener(event, listeners[event])

--- a/src/decorators/bodyMode.js
+++ b/src/decorators/bodyMode.js
@@ -58,9 +58,8 @@ export default function (target) {
   }
 
   target.prototype.bindBodyListener = function (targetArray) {
-    const { id } = this.props
-    const { event, eventOff, possibleCustomEvents,
-      possibleCustomEventsOff } = this.state
+    const {event, eventOff, possibleCustomEvents,
+      possibleCustomEventsOff} = this.state
     const body = getBody()
 
     const customEvents = findCustomEvents(targetArray, 'data-event')

--- a/src/decorators/bodyMode.js
+++ b/src/decorators/bodyMode.js
@@ -36,7 +36,7 @@ export default function (target) {
       const x = clone(e)
       x.currentTarget = target
       x.stopPropagation = () => {}
-      if (!isCapture) e.stopPropagation()
+      if (customEvent && !isCapture) e.stopPropagation()
       callback(x)
     }
   }

--- a/src/decorators/bodyMode.js
+++ b/src/decorators/bodyMode.js
@@ -5,7 +5,6 @@ import {checkStatus} from './customEvent'
 
 export default function (target) {
   target.prototype.isBodyMode = function () {
-    return true
     return this.props.bodyMode
   }
 
@@ -30,12 +29,10 @@ export default function (target) {
       return
     }
 
-    if (tip != null
-      && (!respectEffect || this.getEffect(target) === 'float')
-      && (
-      (id == null && _for == null)
-        || (id != null && _for === id)
-    )) {
+    if (tip != null &&
+      (!respectEffect || this.getEffect(target) === 'float') &&
+      ((id == null && _for == null) || (id != null && _for === id))
+    ) {
       const x = clone(e)
       x.currentTarget = target
       x.stopPropagation = () => {}
@@ -92,5 +89,3 @@ export default function (target) {
     }
   }
 }
-
-

--- a/src/decorators/bodyMode.js
+++ b/src/decorators/bodyMode.js
@@ -73,10 +73,11 @@ export default function (target) {
 
     this.unbindBodyListener(body)
 
-    const listeners = this.bodyModeListeners = {
-      'mouseover': bodyListener.bind(this, this.showTooltip, {}),
-      'mousemove': bodyListener.bind(this, this.updateTooltip, { respectEffect: true }),
-      'mouseout': bodyListener.bind(this, this.hideTooltip, {})
+    const listeners = this.bodyModeListeners = {}
+    if (event == null) {
+      listeners.mouseover = bodyListener.bind(this, this.showTooltip, {})
+      listeners.mousemove = bodyListener.bind(this, this.updateTooltip, { respectEffect: true })
+      listeners.mouseout = bodyListener.bind(this, this.hideTooltip, {})
     }
 
     for (const event in customEvents) {

--- a/src/decorators/customEvent.js
+++ b/src/decorators/customEvent.js
@@ -6,11 +6,10 @@
  * - `eventOff` {String}
  */
 
-const checkStatus = function (dataEventOff, e) {
+export const checkStatus = function (dataEventOff, e) {
   const {show} = this.state
   const {id} = this.props
-  const dataIsCapture = e.currentTarget.getAttribute('data-iscapture')
-  const isCapture = dataIsCapture && dataIsCapture === 'true' || this.props.isCapture
+  const isCapture = this.isCapture(e.currentTarget)
   const currentItem = e.currentTarget.getAttribute('currentItem')
 
   if (!isCapture) e.stopPropagation()

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import windowListener from './decorators/windowListener'
 import customEvent from './decorators/customEvent'
 import isCapture from './decorators/isCapture'
 import getEffect from './decorators/getEffect'
+import bodyMode from './decorators/bodyMode'
 
 /* Utils */
 import getPosition from './utils/getPosition'
@@ -20,7 +21,7 @@ import nodeListToArray from './utils/nodeListToArray'
 /* CSS */
 import cssStyle from './style'
 
-@staticMethods @windowListener @customEvent @isCapture @getEffect
+@staticMethods @windowListener @customEvent @isCapture @getEffect @bodyMode
 class ReactTooltip extends Component {
 
   static propTypes = {
@@ -100,10 +101,6 @@ class ReactTooltip extends Component {
     this.delayShowLoop = null
     this.delayHideLoop = null
     this.intervalUpdateContent = null
-
-    this.bodyUpdateTooltip = this.bodyListener.bind(this, this.updateTooltip, true)
-    this.bodyShowTooltip = this.bodyListener.bind(this, this.showTooltip, false)
-    this.bodyHideTooltip = this.bodyListener.bind(this, this.hideTooltip, false)
   }
 
   /**
@@ -142,11 +139,17 @@ class ReactTooltip extends Component {
   }
 
   componentWillUnmount () {
+    const { bodyMode } = this.props
+
     this.mount = false
 
     this.clearTimer()
 
-    this.unbindListener()
+    if (bodyMode) {
+      this.unbindBodyListener()
+    } else {
+      this.unbindListener()
+    }
     this.removeScrollListener()
     this.unbindWindowEvents()
   }
@@ -163,44 +166,6 @@ class ReactTooltip extends Component {
     }
     // targetArray is a NodeList, convert it to a real array
     return nodeListToArray(targetArray)
-  }
-
-  bodyListener(callback, respectEffect, e) {
-    const {id} = this.props
-
-    const clone = (e) => {
-      const copy = {}
-      for (const key in e) {
-        copy[key] = e[key]
-      }
-      return copy
-    }
-
-    const tip = e.target.dataset.tip
-    const _for = e.target.dataset.for
-
-    const target = e.target
-
-    if (tip != null
-      && (!respectEffect || this.getEffect(target) === 'float')
-      && (
-      (id == null && _for == null)
-        || (id != null && _for === id)
-    )) {
-      const x = clone(e)
-      x.currentTarget = target
-      callback(x)
-    }
-  }
-
-  bindBodyListener() {
-    const body = document.getElementsByTagName('body')[0]
-
-    body.addEventListener('mouseover', this.bodyShowTooltip)
-
-    body.addEventListener('mousemove', this.bodyUpdateTooltip)
-
-    body.addEventListener('mouseout', this.bodyHideTooltip)
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -52,8 +52,8 @@ class ReactTooltip extends Component {
     resizeHide: PropTypes.bool,
     wrapper: PropTypes.string,
     bodyMode: PropTypes.bool,
-    possibleCustomEvents: PropTypes.arrayOf(PropTypes.string),
-    possibleCustomEventsOff: PropTypes.arrayOf(PropTypes.string)
+    possibleCustomEvents: PropTypes.string,
+    possibleCustomEventsOff: PropTypes.string
   };
 
   static defaultProps = {
@@ -88,8 +88,8 @@ class ReactTooltip extends Component {
       ariaProps: parseAria(props), // aria- and role attributes
       isEmptyTip: false,
       disable: false,
-      possibleCustomEvents: props.possibleCustomEvents || [],
-      possibleCustomEventsOff: props.possibleCustomEventsOff || []
+      possibleCustomEvents: props.possibleCustomEvents || '',
+      possibleCustomEventsOff: props.possibleCustomEventsOff || ''
     }
 
     this.bind([

--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,8 @@ class ReactTooltip extends Component {
     if (insecure) {
       this.setStyleHeader() // Set the style to the <link>
     }
-    this.bindListener() // Bind listener for tooltip
+    //this.bindListener() // Bind listener for tooltip
+    this.bindBodyListener() // Bind listener for tooltip
     this.bindWindowEvents(resizeHide) // Bind global event for static method
   }
 
@@ -154,6 +155,43 @@ class ReactTooltip extends Component {
     }
     // targetArray is a NodeList, convert it to a real array
     return nodeListToArray(targetArray)
+  }
+
+  bindBodyListener() {
+    const {id} = this.props
+    const body = document.getElementsByTagName('body')[0]
+
+    const clone = (e) => {
+      const copy = {}
+      for (const key in e) {
+        copy[key] = e[key]
+      }
+      return copy
+    }
+
+    const listener = (callback, respectEffect, e) => {
+      const tip = e.target.dataset.tip
+      const _for = e.target.dataset.for
+
+      const target = e.target
+
+      if (tip != null
+        && (!respectEffect || true || this.getEffect(target) === 'float')
+        && (
+        (id == null && _for == null)
+          || (id != null && _for === id)
+      )) {
+        const x = clone(e)
+        x.currentTarget = target
+        callback(x)
+      }
+    }
+
+    body.addEventListener('mouseover', listener.bind(null, this.showTooltip, false))
+
+    body.addEventListener('mousemove', listener.bind(null, this.updateTooltip, true))
+
+    body.addEventListener('mouseout', listener.bind(null, this.hideTooltip, false))
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,9 @@ class ReactTooltip extends Component {
     scrollHide: PropTypes.bool,
     resizeHide: PropTypes.bool,
     wrapper: PropTypes.string,
-    bodyMode: PropTypes.bool
+    bodyMode: PropTypes.bool,
+    possibleCustomEvents: PropTypes.arrayOf(PropTypes.string),
+    possibleCustomEventsOff: PropTypes.arrayOf(PropTypes.string)
   };
 
   static defaultProps = {
@@ -85,7 +87,9 @@ class ReactTooltip extends Component {
       currentTarget: null, // Current target of mouse event
       ariaProps: parseAria(props), // aria- and role attributes
       isEmptyTip: false,
-      disable: false
+      disable: false,
+      possibleCustomEvents: props.possibleCustomEvents || [],
+      possibleCustomEventsOff: props.possibleCustomEventsOff || []
     }
 
     this.bind([

--- a/src/index.js
+++ b/src/index.js
@@ -112,12 +112,16 @@ class ReactTooltip extends Component {
   }
 
   componentDidMount () {
-    const { insecure, resizeHide } = this.props
+    const { insecure, resizeHide, bodyMode } = this.props
     if (insecure) {
       this.setStyleHeader() // Set the style to the <link>
     }
-    //this.bindListener() // Bind listener for tooltip
-    this.bindBodyListener() // Bind listener for tooltip
+
+    if (bodyMode) {
+      this.bindBodyListener() // Bind single body event listener
+    } else {
+      this.bindListener() // Bind listener for each element
+    }
     this.bindWindowEvents(resizeHide) // Bind global event for static method
   }
 
@@ -176,7 +180,7 @@ class ReactTooltip extends Component {
       const target = e.target
 
       if (tip != null
-        && (!respectEffect || true || this.getEffect(target) === 'float')
+        && (!respectEffect || this.getEffect(target) === 'float')
         && (
         (id == null && _for == null)
           || (id != null && _for === id)

--- a/src/index.js
+++ b/src/index.js
@@ -100,6 +100,10 @@ class ReactTooltip extends Component {
     this.delayShowLoop = null
     this.delayHideLoop = null
     this.intervalUpdateContent = null
+
+    this.bodyUpdateTooltip = this.bodyListener.bind(this, this.updateTooltip, true)
+    this.bodyShowTooltip = this.bodyListener.bind(this, this.showTooltip, false)
+    this.bodyHideTooltip = this.bodyListener.bind(this, this.hideTooltip, false)
   }
 
   /**
@@ -161,9 +165,8 @@ class ReactTooltip extends Component {
     return nodeListToArray(targetArray)
   }
 
-  bindBodyListener() {
+  bodyListener(callback, respectEffect, e) {
     const {id} = this.props
-    const body = document.getElementsByTagName('body')[0]
 
     const clone = (e) => {
       const copy = {}
@@ -173,29 +176,31 @@ class ReactTooltip extends Component {
       return copy
     }
 
-    const listener = (callback, respectEffect, e) => {
-      const tip = e.target.dataset.tip
-      const _for = e.target.dataset.for
+    const tip = e.target.dataset.tip
+    const _for = e.target.dataset.for
 
-      const target = e.target
+    const target = e.target
 
-      if (tip != null
-        && (!respectEffect || this.getEffect(target) === 'float')
-        && (
-        (id == null && _for == null)
-          || (id != null && _for === id)
-      )) {
-        const x = clone(e)
-        x.currentTarget = target
-        callback(x)
-      }
+    if (tip != null
+      && (!respectEffect || this.getEffect(target) === 'float')
+      && (
+      (id == null && _for == null)
+        || (id != null && _for === id)
+    )) {
+      const x = clone(e)
+      x.currentTarget = target
+      callback(x)
     }
+  }
 
-    body.addEventListener('mouseover', listener.bind(null, this.showTooltip, false))
+  bindBodyListener() {
+    const body = document.getElementsByTagName('body')[0]
 
-    body.addEventListener('mousemove', listener.bind(null, this.updateTooltip, true))
+    body.addEventListener('mouseover', this.bodyShowTooltip)
 
-    body.addEventListener('mouseout', listener.bind(null, this.hideTooltip, false))
+    body.addEventListener('mousemove', this.bodyUpdateTooltip)
+
+    body.addEventListener('mouseout', this.bodyHideTooltip)
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -171,6 +171,9 @@ class ReactTooltip extends Component {
         target.setAttribute('currentItem', 'false')
       }
       this.unbindBasicListener(target)
+      if (this.isCustomEvent(target)) {
+        this.customUnbindListener(target)
+      }
     })
 
     if (this.isBodyMode()) {

--- a/src/index.js
+++ b/src/index.js
@@ -182,7 +182,7 @@ class ReactTooltip extends Component {
     })
 
     if (this.isBodyMode()) {
-      this.bindBodyListener()
+      this.bindBodyListener(targetArray)
     } else {
       targetArray.forEach(target => {
         const isCaptureMode = this.isCapture(target)

--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,8 @@ class ReactTooltip extends Component {
     disable: PropTypes.bool,
     scrollHide: PropTypes.bool,
     resizeHide: PropTypes.bool,
-    wrapper: PropTypes.string
+    wrapper: PropTypes.string,
+    bodyMode: PropTypes.bool
   };
 
   static defaultProps = {


### PR DESCRIPTION
This PR related to feature request #137.
This feature is very suitable for me too, so I've tried to implement
it as safe as possible.

# DOM Event properties

In the DOM event object, there are three properties which I think are
interesting for this feature:
1. `currentTarget` - when listener is attached to the `<body>` element,
the `currentTarget` is equals to the `<body>`. That's why it's
inappropriate to call methods like `showTooltip` with such an event
object given.
2. `target` - this is the element which raised the event.
3. `path` - this is an actual path of the event's bubbling flow. We could
traverse `path` to find the element with `[data-tip]` set, even if the
`target` of the event doesn't have the `data-tip` attribute.

# Proposed solution

There are several goals that I pursued:
1. Don't change the existing code as much as possible.
2. Reuse the existing code as much as possible.

So, this PR introduces new mode for the `ReactTooltip`: `bodyMode`
When `ReactTooltip` works in body mode, it attaches listeners to a `<body>`
instead of each individual DOM element.
All events are captured in the "bubbling" phase.

## How to use

To activate the "body mode", you need to set `bodyMode` property:
```jsx
<ReactTooltip bodyMode />
```

## Basic behavior (no custom events)

For every basic event: `mouseenter`, `mousemove` and `mouseleave`,
the proposed implementation attaches listener to the `<body>` for events `mouseover`,
`mousemove` and `mouseout` respectively. 
These listeners has the following algorithm:
1. Check, if `e.target` has `data-tip` attribute and has proper `data-for`.
2. If yes, make proxy of the event object, with `target` assigned to `currentTarget`.
3. Then, call the corresponding function: `showTooltip`, `updateTooltip`
or `hideTooltip` with proxy event given.

`mousemove` is attached, no matter what the `props.effect` is. But
the effect is still handled correctly. There may be a performance issue
for someone who uses only `solid` tooltips.

## Custom events

To handle custom events, corresponding event listeners are attached to
the `<body>`. Event listener attached for every known event type.
The list of known event types consists of:
1. `props.event` (`props.eventOff`)
2. `data-event` (`data-eventOff`) of every element of the `targetArray`
at the time of call `bindBodyListener`
3. `props.possibleCustomEvents` (`props.possibleCustomEventsOff`). This
is the useful suggestion for tooltip, because the `targetArray` may not
contain all the required `data-event` values at the mount time.

## Unbinding

All the event listeners saved into `this.bodyModeListeners`.
So, they are safely detached on unmount/rebuild.

# Known issues

* Nested elements.
When an element associated with the `ReactTooltip` has no nested elements,
everything works well. Otherwise, tooltip would disappear as soon as mouse
pointer reaches nested element. This issue can be fixed by lookup of proper element in `e.path` array.

* No "capture" mode.
For current implementation, `isCapture` is ignored. For some cases, I guess, this issue is related to the previous one, and the "capturing" semantics can be implemented by selecting the appropriate lookup direction.