### PR TITLE
Use prop-types package instead of React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "react-dom": "^0.14.0 || ^15.0.0"
   },
   "dependencies": {
-    "classnames": "^2.2.0"
+    "classnames": "^2.2.0",
+    "prop-types": "^15.5.8"
   },
   "engines": {
     "node": ">=4.2.1"

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom'
 import classname from 'classnames'
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
 import classname from 'classnames'
 


### PR DESCRIPTION
In response to warnings appearing when using React 15.5+