### PR TITLE
Add ability to specify custom DOM element for `scrollHide` scroll events

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ className	|   data-class  |  String  |   | extra custom class, can use !importan
  afterHide | null | Func | () => {} | Function that will be called after tooltip hide
  disable | data-tip-disable | Bool | true, false | Disable the tooltip behaviour, default is false
  scrollHide | data-scroll-hide | Bool | true, false | Hide the tooltip when scrolling, default is true
+ scrollHideSelector | data-scroll-hide-selector | String |  | custom selector to use when determining which DOM element is listening for scroll events to hide tooltip
  resizeHide | null | Bool | true, false | Hide the tooltip when resizing the window, default is true
  wrapper | null | String | div, span | Selecting the wrapper element of the react tooltip, default is div
 

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,7 @@ class ReactTooltip extends Component {
     afterHide: PropTypes.func,
     disable: PropTypes.bool,
     scrollHide: PropTypes.bool,
+    scrollHideSelector: PropTypes.string,
     resizeHide: PropTypes.bool,
     wrapper: PropTypes.string
   };
@@ -378,11 +379,24 @@ class ReactTooltip extends Component {
    */
   addScrollListener (e) {
     const isCaptureMode = this.isCapture(e.currentTarget)
-    window.addEventListener('scroll', this.hideTooltip, isCaptureMode)
+    this.getScrollHideListenerNode().addEventListener('scroll', this.hideTooltip, isCaptureMode)
   }
 
   removeScrollListener () {
-    window.removeEventListener('scroll', this.hideTooltip)
+    this.getScrollHideListenerNode().removeEventListener('scroll', this.hideTooltip)
+  }
+
+  /**
+   * Convenience function to safely get a custom DOM element to listen for
+   * scroll events, falling back to `window` as a default.
+   */
+  getScrollHideListenerNode () {
+    if (!this.props.scrollHideSelector) {
+      return window
+    } else {
+      const node = document.querySelector(this.props.scrollHideSelector)
+      return node || window
+    }
   }
 
   // Calculation the position


### PR DESCRIPTION
Just started using `react-tooltip` this week, really awesome library - thank you guys!

Currently, `scrollHide` just looks for scrollEvents on the `window`. This works well 99% of the time, but if a page has custom scroll containers, the `window` never actually sees any of those scroll events, as they're not fired on the `window`.

This PR just adds a way to plug in a custom selector to replace the window - I don't believe it fixes every problem of https://github.com/wwayne/react-tooltip/issues/248, but it _should_ act as an easy workaround for situations like @philraj was having [here](https://github.com/wwayne/react-tooltip/issues/248#issuecomment-288132725).

I haven't been following the project closely, so I hope this is the proper way to contribute. Thanks!