### PR TITLE
Make getPosition() calculate offsets correctly for svg elements

### DIFF
--- a/src/utils/getPosition.js
+++ b/src/utils/getPosition.js
@@ -15,10 +15,18 @@
  * - `position` {OBject} {left: {Number}, top: {Number}}
  */
 export default function (e, target, node, place, effect, offset) {
-  const tipWidth = node.clientWidth
-  const tipHeight = node.clientHeight
+  const {
+    width: tipWidth,
+    height: tipHeight
+  } = getDimensions(node)
+
+  const {
+    width: targetWidth,
+    height: targetHeight
+  } = getDimensions(target)
+
   const {mouseX, mouseY} = getCurrentOffset(e, target, effect)
-  const defaultOffset = getDefaultPosition(effect, target.clientWidth, target.clientHeight, tipWidth, tipHeight)
+  const defaultOffset = getDefaultPosition(effect, targetWidth, targetHeight, tipWidth, tipHeight)
   const {extraOffset_X, extraOffset_Y} = calculateOffset(offset)
 
   const windowWidth = window.innerWidth
@@ -161,13 +169,23 @@ export default function (e, target, node, place, effect, offset) {
   }
 }
 
+const getDimensions = (node) => {
+  const { height, width } = node.getBoundingClientRect()
+  return {
+    height: parseInt(height, 10),
+    width: parseInt(width, 10)
+  }
+}
+
 // Get current mouse offset
 const getCurrentOffset = (e, currentTarget, effect) => {
   const boundingClientRect = currentTarget.getBoundingClientRect()
   const targetTop = boundingClientRect.top
   const targetLeft = boundingClientRect.left
-  const targetWidth = currentTarget.clientWidth
-  const targetHeight = currentTarget.clientHeight
+  const {
+    width: targetWidth,
+    height: targetHeight
+  } = getDimensions(currentTarget)
 
   if (effect === 'float') {
     return {


### PR DESCRIPTION
Current implementation of getPosition is broken for children of svg elements.
Their clientHeight and clientWidth values are usually (or always, not sure, though) equal to 0, therefore calculated offsets are wrong.
This may be a common issue for tooltips whose tips are some sort of svg child elements, like polygon, rect, line, circle etc. In such cases, their placement is usually wrong.
