### PR TITLE
Fix issue where tooltip won't show for adjacent elements.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -234,7 +234,7 @@ class ReactTooltip extends Component {
       // Don't trigger other elements belongs to other ReactTooltip
       const targetArray = this.getTargetArray(this.props.id)
       const isMyElement = targetArray.some(ele => ele === e.currentTarget)
-      if (!isMyElement || this.state.show) return
+      if (!isMyElement) return
     }
     // Get the tooltip content
     // calculate in this phrase so that tip width height can be detected


### PR DESCRIPTION
Deleting this one statement fixes the issue where tooltips won't show when mousing over to adjacent elements. Referenced in [#235](https://github.com/wwayne/react-tooltip/issues/235). 

Fixes #235