### PR TITLE
fix(index.js): add missing argument so tooltip hides.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -295,7 +295,7 @@ class ReactTooltip extends Component {
         this.intervalUpdateContent = setInterval(() => {
           if (this.mount) {
             const {getContent} = this.props
-            const placeholder = getTipContent(originTooltip, getContent[0](), isMultiline)
+            const placeholder = getTipContent(originTooltip, '', getContent[0](), isMultiline)
             const isEmptyTip = typeof placeholder === 'string' && placeholder === ''
             this.setState({
               placeholder,


### PR DESCRIPTION
If getContent returns '', the tooltip should hide. A missing
argument caused this not to work for dynamic content.