### PR TITLE
fix(index.js): fix state initialization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,8 @@ class ReactTooltip extends React.Component {
   constructor (props) {
     super(props)
     this.state = {
-      place: 'top', // Direction of tooltip
+      place: props.place || 'top', // Direction of tooltip
+      desiredPlace: props.place || 'top',
       type: 'dark', // Color theme of tooltip
       effect: 'float', // float or fixed
       show: false,


### PR DESCRIPTION
This component occuers exception from v3.8.1 .
In IE11 and Edge, mouse move event is trigger before mouse enter.
So, when placeholder is exist, `updateTooltip` makes error.
(See example's `Advance features` on the browser)

I think it is resolved by correct initialization.
How about this?

Regard.