### PR TITLE
added support for passing options to sanitizeHtml

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,8 @@ class ReactTooltip extends React.Component {
     disable: PropTypes.bool,
     scrollHide: PropTypes.bool,
     resizeHide: PropTypes.bool,
-    wrapper: PropTypes.string
+    wrapper: PropTypes.string,
+    sanitizeHtmlOptions: PropTypes.any
   };
 
   static defaultProps = {
@@ -549,7 +550,7 @@ class ReactTooltip extends React.Component {
                  ref={ref => this.tooltipRef = ref}
                  {...ariaProps}
                  data-id='tooltip'
-                 dangerouslySetInnerHTML={{__html: sanitizeHtml(placeholder)}}/>
+                 dangerouslySetInnerHTML={{__html: sanitizeHtml(placeholder, this.props.sanitizeHtmlOptions)}}/>
       )
     } else {
       return (


### PR DESCRIPTION
This adds support for passing options into sanitizeHtml.  
Now the user can specify which HTML attributes can be passed into the text of the tooltip as defined here: https://www.npmjs.com/package/sanitize-html.

This was necessary because I am passing HTML into the tooltip text and I wanted more freedom to format the text as I pleased.  