### PR TITLE
Support for older versions of firefox

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -164,9 +164,15 @@ class ReactTooltip extends React.Component {
     const {show} = this.state
 
     if (show && this.tooltipRef) {
-      /* old IE work around */
+      /* old IE or Firefox work around */
       if (!this.tooltipRef.matches) {
-        this.tooltipRef.matches = this.tooltipRef.msMatchesSelector
+        /* old IE work around */
+        if(this.tooltipRef.msMatchesSelector) {
+          this.tooltipRef.matches = this.tooltipRef.msMatchesSelector;
+        } else {
+          /* old Firefox work around */
+          this.tooltipRef.matches = this.tooltipRef.mozMatchesSelector;
+        }
       }
       return this.tooltipRef.matches(':hover')
     }

--- a/src/index.js
+++ b/src/index.js
@@ -167,11 +167,11 @@ class ReactTooltip extends React.Component {
       /* old IE or Firefox work around */
       if (!this.tooltipRef.matches) {
         /* old IE work around */
-        if(this.tooltipRef.msMatchesSelector) {
-          this.tooltipRef.matches = this.tooltipRef.msMatchesSelector;
+        if (this.tooltipRef.msMatchesSelector) {
+          this.tooltipRef.matches = this.tooltipRef.msMatchesSelector
         } else {
           /* old Firefox work around */
-          this.tooltipRef.matches = this.tooltipRef.mozMatchesSelector;
+          this.tooltipRef.matches = this.tooltipRef.mozMatchesSelector
         }
       }
       return this.tooltipRef.matches(':hover')


### PR DESCRIPTION
'matches' function is not supported in older versions of firefox and currently this component only have a workaround implemented for old versions of internet explorer. I'm expanding that in order to support old versions of firefox as well.