### PR TITLE
feat(overridePosition): Add "overridePosition" property to handle border cases and customize position

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ className	|   data-class  |  String  |   | extra custom class, can use !importan
  getContent | null | Func or Array | (dataTip) => {}, [(dataTip) => {}, Interval] | Generate the tip content dynamically
  afterShow | null | Func | (evt) => {} | Function that will be called after tooltip show, with event that triggered show
  afterHide | null | Func | (evt) => {} | Function that will be called after tooltip hide, with event that triggered hide
+ overridePosition | null | Func | ({left:number, top: number}, currentEvent, currentTarget, node, place, desiredPlace, effect, offset) => ({left: number, top: number}) | Function that will replace tooltip position with custom one
  disable | data-tip-disable | Bool | true, false | Disable the tooltip behaviour, default is false
  scrollHide | data-scroll-hide | Bool | true, false | Hide the tooltip when scrolling, default is true
  resizeHide | null | Bool | true, false | Hide the tooltip when resizing the window, default is true

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,7 @@ class ReactTooltip extends React.Component {
     scrollHide: PropTypes.bool,
     resizeHide: PropTypes.bool,
     wrapper: PropTypes.string,
+    overridePosition: PropTypes.func,
     clickable: PropTypes.bool
   };
 
@@ -309,6 +310,10 @@ class ReactTooltip extends React.Component {
     let effect = switchToSolid && 'solid' || this.getEffect(e.currentTarget)
     let offset = e.currentTarget.getAttribute('data-offset') || this.props.offset || {}
     let result = getPosition(e, e.currentTarget, this.tooltipRef, desiredPlace, desiredPlace, effect, offset)
+    if (this.props.overridePosition) {
+      result = this.props.overridePosition(result, e.currentTarget, this.tooltipRef, desiredPlace, desiredPlace, effect, offset)
+    }
+
     let place = result.isNewState ? result.newState.place : desiredPlace
 
     // To prevent previously created timers from triggering
@@ -480,7 +485,10 @@ class ReactTooltip extends React.Component {
   updatePosition () {
     const {currentEvent, currentTarget, place, desiredPlace, effect, offset} = this.state
     const node = this.tooltipRef
-    const result = getPosition(currentEvent, currentTarget, node, place, desiredPlace, effect, offset)
+    let result = getPosition(currentEvent, currentTarget, node, place, desiredPlace, effect, offset)
+    if (this.props.overridePosition) {
+      result = this.props.overridePosition(result, currentEvent, currentTarget, node, place, desiredPlace, effect, offset)
+    }
 
     if (result.isNewState) {
       // Switch to reverse placement

--- a/src/index.js
+++ b/src/index.js
@@ -53,11 +53,11 @@ class ReactTooltip extends React.Component {
     getContent: PropTypes.any,
     afterShow: PropTypes.func,
     afterHide: PropTypes.func,
+    overridePosition: PropTypes.func,
     disable: PropTypes.bool,
     scrollHide: PropTypes.bool,
     resizeHide: PropTypes.bool,
     wrapper: PropTypes.string,
-    overridePosition: PropTypes.func,
     clickable: PropTypes.bool
   };
 
@@ -310,8 +310,8 @@ class ReactTooltip extends React.Component {
     let effect = switchToSolid && 'solid' || this.getEffect(e.currentTarget)
     let offset = e.currentTarget.getAttribute('data-offset') || this.props.offset || {}
     let result = getPosition(e, e.currentTarget, this.tooltipRef, desiredPlace, desiredPlace, effect, offset)
-    if (this.props.overridePosition) {
-      result = this.props.overridePosition(result, e.currentTarget, this.tooltipRef, desiredPlace, desiredPlace, effect, offset)
+    if (result.position && this.props.overridePosition) {
+      result.position = this.props.overridePosition(result.position, e.currentTarget, this.tooltipRef, desiredPlace, desiredPlace, effect, offset)
     }
 
     let place = result.isNewState ? result.newState.place : desiredPlace
@@ -487,7 +487,7 @@ class ReactTooltip extends React.Component {
     const node = this.tooltipRef
     let result = getPosition(currentEvent, currentTarget, node, place, desiredPlace, effect, offset)
     if (this.props.overridePosition) {
-      result = this.props.overridePosition(result, currentEvent, currentTarget, node, place, desiredPlace, effect, offset)
+      result.position = this.props.overridePosition(result.position, currentEvent, currentTarget, node, place, desiredPlace, effect, offset)
     }
 
     if (result.isNewState) {


### PR DESCRIPTION
In border cases current algorithm for getting position, when tooltip is too long, will display it in invisible area of the window, to tip will be partially visible. This can be prevented by Math.min/max body.clientWidth/Height and current { left, top } positions. Such extension can not break any existing behaviour since it is just an optional property.