### PR TITLE
fix(wrapper): consistent classname for ssr hydrate

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -569,7 +569,7 @@ class ReactTooltip extends React.Component {
     if (ReactTooltip.supportedWrappers.indexOf(Wrapper) < 0) {
       Wrapper = ReactTooltip.defaultProps.wrapper
     }
-    const wrapperClassName = [tooltipClass, extraClass].filter(Boolean).join(' ');
+    const wrapperClassName = [tooltipClass, extraClass].filter(Boolean).join(' ')
 
     if (html) {
       return (

--- a/src/index.js
+++ b/src/index.js
@@ -569,10 +569,11 @@ class ReactTooltip extends React.Component {
     if (ReactTooltip.supportedWrappers.indexOf(Wrapper) < 0) {
       Wrapper = ReactTooltip.defaultProps.wrapper
     }
+    const wrapperClassName = [tooltipClass, extraClass].filter(Boolean).join(' ');
 
     if (html) {
       return (
-        <Wrapper className={`${tooltipClass} ${extraClass}`}
+        <Wrapper className={wrapperClassName}
                  id={this.props.id}
                  ref={ref => this.tooltipRef = ref}
                  {...ariaProps}
@@ -581,7 +582,7 @@ class ReactTooltip extends React.Component {
       )
     } else {
       return (
-        <Wrapper className={`${tooltipClass} ${extraClass}`}
+        <Wrapper className={wrapperClassName}
                  id={this.props.id}
                  {...ariaProps}
                  ref={ref => this.tooltipRef = ref}


### PR DESCRIPTION
Fix hydrate issue
```javascript
Warning: Prop className did not match. Server: "__react_component_tooltip place-top type-dark" Client: "__react_component_tooltip place-top type-dark "
```
[Hydrate documentation](https://reactjs.org/docs/react-dom.html#hydrate).