### PR TITLE
fix: Release event listeners

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -169,7 +169,7 @@ class ReactTooltip extends React.Component {
     this.clearTimer();
 
     this.unbindListener();
-    this.removeScrollListener();
+    this.removeScrollListener(this.state.currentTarget);
     this.unbindWindowEvents();
   }
 
@@ -573,7 +573,7 @@ class ReactTooltip extends React.Component {
       this.removeListenerForTooltipExit();
 
       this.setState({ show: false }, () => {
-        this.removeScrollListener();
+        this.removeScrollListener(this.state.currentTarget);
         if (isVisible && afterHide) {
           afterHide(e);
         }
@@ -604,8 +604,9 @@ class ReactTooltip extends React.Component {
     window.addEventListener("scroll", this.hideTooltipOnScroll, isCaptureMode);
   }
 
-  removeScrollListener() {
-    window.removeEventListener("scroll", this.hideTooltipOnScroll);
+  removeScrollListener(currentTarget) {
+    const isCaptureMode = this.isCapture(currentTarget);
+    window.removeEventListener("scroll", this.hideTooltipOnScroll, isCaptureMode);
   }
 
   // Calculation the position


### PR DESCRIPTION
Fix for issue: #533

This patch applied on top of `v3.10.1` works fine in the `make dev` test except for the test scrolling test, which appears to work as it does in master. With a slight tweak, this patch can be applied on master.

@aronhelser Can we get a release with this patch applied to `v3.10.0`, or if not, then `v3.10.1`?

Details on the test scrolling test: The left example should hide the tooltip when scrolling. This happens on the first time, but moving the mouse slightly makes the tooltip reappear, and it does not hide again when scrolling again. This is also how it behaves without this PR's patch.