### PR TITLE
fix: providing currentTarget in overridePosition

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -382,6 +382,7 @@ class ReactTooltip extends React.Component {
       result.position = this.props.overridePosition(
         result.position,
         e,
+        e.currentTarget,
         this.tooltipRef,
         desiredPlace,
         desiredPlace,


### PR DESCRIPTION
The overridePosition argument was missing, so I added it

Now, In the example, as shown in the image below, NaN is generated as position.
Temporarily added console.log [here](https://github.com/wwayne/react-tooltip/blob/master/example/src/App.js#L772) for confirmation
![image](https://user-images.githubusercontent.com/233012/76519657-ba3a0480-64a4-11ea-8d6f-1ad63c4c73ed.png)
