### PR TITLE
fix: fix ie edge CustomEvent bug

### DIFF
--- a/src/decorators/staticMethods.js
+++ b/src/decorators/staticMethods.js
@@ -12,8 +12,7 @@ const dispatchGlobalEvent = (eventName, opts) => {
     event = new window.CustomEvent(eventName, { detail: opts });
   } else {
     event = document.createEvent("Event");
-    event.initEvent(eventName, false, true);
-    event.detail = opts;
+    event.initEvent(eventName, false, true, opts);
   }
 
   window.dispatchEvent(event);


### PR DESCRIPTION
switches details to be included in the CustomEvent.initCustomEvent constructor

fix #498

See references here:
- https://stackoverflow.com/questions/26596123/internet-explorer-9-10-11-event-constructor-doesnt-work
- https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/ff975987(v%3Dvs.85)