### PR TITLE
fix(src/decorators/staticMethods.js): fixing another IE event bug

### DIFF
--- a/src/decorators/staticMethods.js
+++ b/src/decorators/staticMethods.js
@@ -6,6 +6,7 @@ import CONSTANT from "../constant";
 const dispatchGlobalEvent = (eventName, opts) => {
   // Compatible with IE
   // @see http://stackoverflow.com/questions/26596123/internet-explorer-9-10-11-event-constructor-doesnt-work
+  // @see https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent
   let event;
 
   if (typeof window.CustomEvent === "function") {
@@ -52,10 +53,11 @@ export default function(target) {
 
   target.prototype.globalShow = function(event) {
     if (this.mount) {
+      const hasTarget =
+        (event && event.detail && event.detail.target && true) || false;
       // Create a fake event, specific show will limit the type to `solid`
       // only `float` type cares e.clientX e.clientY
-      const e = { currentTarget: event.detail.target };
-      this.showTooltip(e, true);
+      this.showTooltip({ currentTarget: hasTarget && event.detail.target }, true);
     }
   };
 


### PR DESCRIPTION
fixing currentTarget for static method global show (in IE)

After making a partial fix last night for IE edge, this popped up in my error logs...
```
Unable to get property 'target' of undefined or null reference

./node_modules/react-tooltip/dist/index.es.js in t.prototype.globalShow at line 1385:1
  target.prototype.globalShow = function (event) {
    if (this.mount) {
      // Create a fake event, specific show will limit the type to `solid`
      // only `float` type cares e.clientX e.clientY
      var e = {
        currentTarget: event.detail.target
      };
      this.showTooltip(e, true);
    }
  };
```

So this PR has a simple fix to prevent the error.