### PR TITLE
Add license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "react-tooltip",
   "version": "0.0.0-semantic-release",
   "description": "react tooltip component",
+  "license": "MIT",
   "main": "dist/index.js",
   "types": "react-tooltip.d.ts",
   "module": "dist/index.es.js",


### PR DESCRIPTION
yarn is issuing a warning when it's missing