### PR TITLE
Mark prop-types and uuid as external to avoid bundling them

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -51,5 +51,6 @@ export default {
     }),
     resolve(),
     commonjs()
-  ]
+  ],
+  external: ["prop-types", "uuid"]
 };


### PR DESCRIPTION
prop-types and uuid are currently marked as "dependencies" but are also bundled by rollup.

This PR proposes to configure them as "external" to avoid bundling them.