### PR TITLE
fix: made it possible to pass uuid instead of generating one internally

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ class ReactTooltip extends React.Component {
     super(props);
 
     this.state = {
-      uuid: generateUUID(),
+      uuid: props.uuid || generateUUID(),
       place: props.place || "top", // Direction of tooltip
       desiredPlace: props.place || "top",
       type: "dark", // Color theme of tooltip


### PR DESCRIPTION
When passing the `uuid` prop ReactTooltip will not generate one itself so you can have a predictable
ID when using SSR strategies"

fix #580