### PR TITLE
docs(readme): Avoid recommending sanitize-html-react

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Notes:
 
 ### Security Note
 
-The `html` option allows a tooltip to directly display raw HTML. This is a security risk if any of that content is supplied by the user. Any user-supplied content must be sanitized, using a package like [sanitize-html-react](https://www.npmjs.com/package/sanitize-html-react). We chose not to include sanitization after discovering it [increased our package size](https://github.com/wwayne/react-tooltip/issues/429) too much - we don't want to penalize people who don't use the `html` option.
+The `html` option allows a tooltip to directly display raw HTML. This is a security risk if any of that content is supplied by the user. Any user-supplied content must be sanitized, using a package like [sanitize-html](https://www.npmjs.com/package/sanitize-html). We chose not to include sanitization after discovering it [increased our package size](https://github.com/wwayne/react-tooltip/issues/429) too much - we don't want to penalize people who don't use the `html` option.
 
 #### Note
 


### PR DESCRIPTION
Hello.

Your readme currently recommends people use `sanitize-html-react` to sanitize HTML.
This library is outdated and vulnerable to XSS.

Here is a full write up on my website:
https://mobeigi.com/blog/security/xss/sanitize-html-react-vulnerability/

Instead, I propose we recommend `sanitize-html` instead which is actively maintained and what `sanitize-html-react` was originally forked off four years ago.

Thanks.