### PR TITLE
fix: do not delay show if tooltip is already shown

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -539,7 +539,6 @@ class ReactTooltip extends React.Component {
     const { delayShow, disable } = this.state;
     const { afterShow } = this.props;
     const placeholder = this.getTooltipContent();
-    const delayTime = parseInt(delayShow, 10);
     const eventTarget = e.currentTarget || e.target;
 
     // Check if the mouse is actually over the tooltip, if so don't hide the tooltip
@@ -551,6 +550,8 @@ class ReactTooltip extends React.Component {
     if (this.isEmptyTip(placeholder) || disable) {
       return;
     }
+
+    const delayTime = !this.state.show ? parseInt(delayShow, 10) : 0;
 
     const updateState = () => {
       if (
@@ -575,7 +576,7 @@ class ReactTooltip extends React.Component {
     };
 
     clearTimeout(this.delayShowLoop);
-    if (delayShow) {
+    if (delayTime) {
       this.delayShowLoop = setTimeout(updateState, delayTime);
     } else {
       updateState();


### PR DESCRIPTION
## Issue

Currently, `delayShow` (or `data-delay-show`) is enforced anytime `updateTooltip` is called, whether the tooltip was already shown or not. 

This results in particularly undesirable behavior when using `delayUpdate` and `delayShow` in conjunction, because after the delayed update occurs, the position of the tooltip is not updated until an additional `delayShow` timeout completes. The undesirable behavior can be seen on the [library's demo page](https://wwayne.github.io/react-tooltip/) under the heading *Demonstrate using mouse in tooltip*.

![react-tooltip-delay-show-issue](https://user-images.githubusercontent.com/8812820/109176012-5dd30200-7754-11eb-869d-5158b97e6d9c.gif).

Notice how the contents of each tooltip are updated briefly before the tooltip is repositioned.

## Fix

This change makes it so `delayShow` will only be enforced if the tooltip is not currently being shown.

A more conservative alternative might be to only not enforce `delayShow` if a positive `delayUpdate` (or `data-delay-update`) is specified, but I believe this simpler solution represents the expected behavior.

Certainly open to feedback on this!