### PR TITLE
fix(src/index.js): hide tooltip if blurred (tabbed out)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -297,7 +297,7 @@ class ReactTooltip extends React.Component {
           );
         }
         target.addEventListener('mouseleave', this.hideTooltip, isCaptureMode);
-        target.addEventListener('blur', this.showTooltip, isCaptureMode);
+        target.addEventListener('blur', this.hideTooltip, isCaptureMode);
       });
     }
 


### PR DESCRIPTION
Fixes hiding tooltip when tabbing out of element. 
References this previous commit (Thanks @muhammadtarek for catching this) 
https://github.com/wwayne/react-tooltip/pull/695#discussion_r626010845