### PR TITLE
fix: performance issue caused by excessive use of clearTimeout/Interval

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -587,10 +587,13 @@ class ReactTooltip extends React.Component {
       }
     };
 
-    clearTimeout(this.delayShowLoop);
+    if (this.delayShowLoop) {
+      clearTimeout(this.delayShowLoop);
+    }
     if (delayTime) {
       this.delayShowLoop = setTimeout(updateState, delayTime);
     } else {
+      this.delayShowLoop = null;
       updateState();
     }
   }
@@ -737,10 +740,22 @@ class ReactTooltip extends React.Component {
    * CLear all kinds of timeout of interval
    */
   clearTimer() {
-    clearTimeout(this.delayShowLoop);
-    clearTimeout(this.delayHideLoop);
-    clearTimeout(this.delayReshow);
-    clearInterval(this.intervalUpdateContent);
+    if (this.delayShowLoop) {
+      clearTimeout(this.delayShowLoop);
+      this.delayShowLoop = null;
+    }
+    if (this.delayHideLoop) {
+      clearTimeout(this.delayHideLoop);
+      this.delayHideLoop = null;
+    }
+    if (this.delayReshow) {
+      clearTimeout(this.delayReshow);
+      this.delayReshow = null;
+    }
+    if (this.intervalUpdateContent) {
+      clearInterval(this.intervalUpdateContent);
+      this.intervalUpdateContent = null;
+    }
   }
 
   hasCustomColors() {


### PR DESCRIPTION
When a large number of tooltips are mounted, there is an excessive amount of unnecessary `clearTimeout()` and `clearInterval()` calls being made, which cause very slow re-renders. In our case, this PR alone shaved off much the re-render time of one particularly expensive re-render (850ms to 472ms).