### PR TITLE
fix(aftershow): call afterShow only after state has fully updated

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -581,10 +581,11 @@ class ReactTooltip extends React.Component {
             show: true
           },
           () => {
-            this.updatePosition();
-            if (isInvisible && afterShow) {
-              afterShow(e);
-            }
+            this.updatePosition(() => {
+              if (isInvisible && afterShow) {
+                afterShow(e);
+              }
+            });
           }
         );
       }
@@ -692,7 +693,7 @@ class ReactTooltip extends React.Component {
   }
 
   // Calculation the position
-  updatePosition() {
+  updatePosition(callbackAfter) {
     const {
       currentEvent,
       currentTarget,
@@ -727,9 +728,11 @@ class ReactTooltip extends React.Component {
     if (result.isNewState) {
       // Switch to reverse placement
       return this.setState(result.newState, () => {
-        this.updatePosition();
+        this.updatePosition(callbackAfter);
       });
     }
+
+    callbackAfter();
 
     // Set tooltip position
     node.style.left = result.position.left + 'px';


### PR DESCRIPTION
`afterShow` was called in the callback of a `setState`, but in the same callback `updatePosition` was also called which did another `setState`. Due to the asynchronous nature of setState that means that `afterShow` did not actually see the actual updated state. This fixes it by forwarding/moving the callback into the innermost `setState` callback. It is a bit annoying/nested but works. Suggestions welcome. Moving to hooks might be the appropriate cleanup, but that would be a somewhat larger task.

Thanks!