### PR TITLE
fix(react18): tip not hiding with React 18 StrictMode enabled

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -148,6 +148,7 @@ class ReactTooltip extends React.Component {
 
   componentDidMount() {
     const { insecure, resizeHide } = this.props;
+    this.mount = true;
 
     this.bindListener(); // Bind listener for tooltip
     this.bindWindowEvents(resizeHide); // Bind global event for static method


### PR DESCRIPTION
Fixes an issue where the tooltip will not hide after hover.

In React 18 StrictMode, components may mount and unmount more than once
See here https://github.com/reactwg/react-18/discussions/19

Closes #754 