### PR TITLE
fix: Its instance type 'ReactTooltip' is not a valid JSX element.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ import 'core-js/modules/es.array.find';
 @getEffect
 @bodyMode
 @trackRemoval
-class ReactTooltip extends React.Component {
+class ReactTooltip extends React.ReactNode {
   static get propTypes() {
     return {
       uuid: PropTypes.string,


### PR DESCRIPTION
Fix new problem with error 'Its instance type 'ReactTooltip' is not a valid JSX element.' and 'Type 'React.ReactNode' is not assignable to type 'import("/node_modules/@types/react-dom/node_modules/@types/react/index").ReactNode'.'